### PR TITLE
Add PowerShell Custom Prompt support and fix completion repetition issue

### DIFF
--- a/CHANGE_LOGS.md
+++ b/CHANGE_LOGS.md
@@ -1,5 +1,8 @@
 # Version Change Logs
 
+### Version 3.0.8
+> Added PowerShell Custom Prompt support
+
 ### Version 3.0.7
 > Added set command with local and global branch prefix & moved setDefaultBranch to here
 

--- a/CHANGE_LOGS.md
+++ b/CHANGE_LOGS.md
@@ -1,7 +1,7 @@
 # Version Change Logs
 
 ### Version 3.0.8
-> Added PowerShell Custom Prompt support
+> Added PowerShell Custom Prompt support + fixed completion repetition issue 
 
 ### Version 3.0.7
 > Added set command with local and global branch prefix & moved setDefaultBranch to here

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
     - [MacOS ZSH](#macos-zsh)
     - [Windows PowerShell](#windows-powershell-1)
   - [Custom Prompt](#custom-prompt)
+    - [Linux/MacOS](#linuxmacos)
+    - [Windows PowerShell](#windows-powershell-2)
   - [Commands](#commands)
     - [Examples](#examples)
   - [Contributing](#contributing)
@@ -29,11 +31,11 @@
 
 > **A bash tool to facilitate managing git branches with long cryptic names with aliases**
 
-The `gitBranchTool`, `g`, command provides additional functionalities around working with *git* branches. 
+The `gitBranchTool`, `g`, command provides additional functionalities around working with _git_ branches.
 
 If you frequently work with long branch names that include developer names, project names, issue numbers, and etc this tool is for you. With `gitBranchTool` or `g`, you'll be able to assign **alias names** for **each branch**.
 
-You can monitor, switch, and delete your branches **using the aliases** instead of the long and confusing branch names (`g` commands **support both branch names and aliases**, so you wouldn't have to use *git* for any of your branch switching needs).
+You can monitor, switch, and delete your branches **using the aliases** instead of the long and confusing branch names (`g` commands **support both branch names and aliases**, so you wouldn't have to use _git_ for any of your branch switching needs).
 
 Additionally, You can add notes to each branch to fully remember what they were about so you can keep the aliases shorter. You can list branches with their aliases and notes at anytime.
 
@@ -48,12 +50,14 @@ On top of all these, `g` provides a **custom prompt** that displays the name of 
 1. Download the artifact `g-linux-vX.X.X` from the latest release [here](https://github.com/cyrus2281/gitBranchTool/releases)
 
 2. Add the binary to your PATH environment variable (or to a directory that is already in your PATH)
-> A directory that is already in your PATH is `/usr/local/bin/` or `/usr/bin/`
+   > A directory that is already in your PATH is `/usr/local/bin/` or `/usr/bin/`
+
 ```bash
 sudo mv g-linux-vX.X.X /usr/local/bin/g
 ```
 
 3. Ensure the binary has the correct permissions
+
 ```bash
 sudo chmod 755 /usr/local/bin/g
 ```
@@ -63,12 +67,14 @@ sudo chmod 755 /usr/local/bin/g
 1. Download the artifact `g-macos-vX.X.X` from the latest release [here](https://github.com/cyrus2281/gitBranchTool/releases)
 
 2. Add the binary to your PATH environment variable (or to a directory that is already in your PATH)
-> A directory that is already in your PATH is `/usr/local/bin/` or `/usr/bin/`
+   > A directory that is already in your PATH is `/usr/local/bin/` or `/usr/bin/`
+
 ```bash
 sudo mv g-macos-vX.X.X /usr/local/bin/g
 ```
 
 3. Ensure the binary has the correct permissions
+
 ```bash
 sudo chmod 755 /usr/local/bin/g
 ```
@@ -78,12 +84,14 @@ sudo chmod 755 /usr/local/bin/g
 1. Download the artifact `g-win-vX.X.X` from the latest release [here](https://github.com/cyrus2281/gitBranchTool/releases)
 
 2. Add the binary to your PATH environment variable (or to a directory that is already in your PATH)
-> A directory that is already in your PATH is `C:\Windows\System32\` (you may need to run PowerShell as an administrator)
+   > A directory that is already in your PATH is `C:\Windows\System32\` (you may need to run PowerShell as an administrator)
+
 ```powershell
 Move-Item -Force -Path .\g-win-vX.X.X.exe -Destination C:\Windows\System32\g.exe
 ```
 
 3. Ensure the binary has the correct permissions (by default, the permissions are set to `Everyone: (RX)`)
+
 ```powershell
 icacls C:\Windows\System32\g.exe /grant 'Everyone:(RX)'
 ```
@@ -118,8 +126,8 @@ echo "\nautoload -U compinit; compinit" >> ~/.zshrc
 sudo mkdir -p ${fpath[1]} && sudo touch ${fpath[1]}/_g && USER=$(whoami); sudo chown $USER ${fpath[1]}/_g && sudo chmod 755 ${fpath[1]}/_g && sudo g completion zsh > "${fpath[1]}/_g"
 ```
 
-
 ### Windows PowerShell
+
 Add the following to your PowerShell profile file (`$PROFILE`):
 
 ```powershell
@@ -127,52 +135,62 @@ g completion powershell | Out-String | Invoke-Expression
 ```
 
 For default PowerShell profile file, run the following command:
+
 ```powershell
 echo "g completion powershell | Out-String | Invoke-Expression" >> $PROFILE
 ```
 
 ## Custom Prompt
 
-Run the following command to your terminal profile to add the gitBranchTool custom prompt. 
+### Linux/MacOS
+
+Run the following command to add the gitBranchTool custom prompt to your shell profile file:
+
 - Change `.bashrc` with `.zshrc` if you use ZSH, or the profile file you use if it's different.
 
 ```bash
 echo -e "\nPROMPT_COMMAND='export PS1=\"\$(g _ps)\"'\nprecmd() { eval \"\$PROMPT_COMMAND\"; }" >> ~/.bashrc
 ```
 
-- Custom prompt is not supported in Windows PowerShell yet.
+### Windows PowerShell
 
+Run the following command to add the gitBranchTool custom prompt to your PowerShell profile file:
+
+```powershell
+echo "function prompt { g _ps }" >> $PROFILE
+```
 
 ## Commands
+
 ```md
 A bash tool to facilitate managing git branches with long cryptic names with aliases
 
 Usage:
-  g [command]
+g [command]
 
 Available Commands:
-  addAlias         Adds alias and note to a branch that is not stored yet
-  completion       Generate the autocompletion script for the specified shell
-  create           Creates a branch with name, alias, and note, and checks into it
-  currentBranch    Returns the name of active branch with alias and note
-  delete           Deletes listed branches base on name or alias
-  getBranchAlias   Gets the branch alias
-  getHome          Get the gitBranchTool's home directory path
-  help             Help about any command
-  list             Lists all branches with their name, alias, and notes
-  removeEntry      Removes a registered branch entry without deleting the branch
-  rename           Updates the alias for the given branch name
-  resolveAlias     Resolves the branch name from an alias
-  setDefaultBranch Change the default branch, default is main
-  switch           Switches to the branch with the given name or alias
-  updateBranchNote Adds/updates the notes for a branch base on name/alias
-  updateCheck      Checks if a newer version is available
+addAlias Adds alias and note to a branch that is not stored yet
+completion Generate the autocompletion script for the specified shell
+create Creates a branch with name, alias, and note, and checks into it
+currentBranch Returns the name of active branch with alias and note
+delete Deletes listed branches base on name or alias
+getBranchAlias Gets the branch alias
+getHome Get the gitBranchTool's home directory path
+help Help about any command
+list Lists all branches with their name, alias, and notes
+removeEntry Removes a registered branch entry without deleting the branch
+rename Updates the alias for the given branch name
+resolveAlias Resolves the branch name from an alias
+set Set configuration options (Run `g set --help` for more information)  
+ switch Switches to the branch with the given name or alias
+updateBranchNote Adds/updates the notes for a branch base on name/alias
+updateCheck Checks if a newer version is available
 
 Flags:
-  -h, --help      help for g
-  -N, --no-log    no logs
-  -V, --verbose   verbose output
-  -v, --version   version for g
+-h, --help help for g
+-N, --no-log no logs
+-V, --verbose verbose output
+-v, --version version for g
 
 Use "g [command] --help" for more information about a command.
 ```
@@ -180,40 +198,46 @@ Use "g [command] --help" for more information about a command.
 ### Examples
 
 - **Create Branch**
+
 ```bash
 g c cyrus/jira-60083 banner "Adds banner to the home page"
 ```
 
 - **Add alias to existing branch**
+
 ```bash
 g a cyrus/jira-60083 banner "Adds banner to the home page"
 ```
 
 - **List all branches**
+
 ```bash
 g l
 ```
 
 - **Switch to branch**
+
 ```bash
 g s banner
 ```
 
 - **Delete branch**
+
 ```bash
 g d banner
 ```
 
 - **Delete multiple branches**
+
 ```bash
 g d banner cyrus/jira-50930
 ```
 
 - **Upgrade the tool to latest version**
+
 ```bash
 g uc -y
 ```
-
 
 ## Contributing
 
@@ -223,15 +247,18 @@ If you have any suggestions or issues, please open an issue or a pull request.
 In your pull request, please include a description of the changes you made and why you made them, and update the [CHANGE_LOGS.md](./CHANGE_LOGS.md), [VERSION](./VERSION), and [README.md](./README.md) (to contributors section) files accordingly.
 
 For versioning
+
 - Patch version: Bug fixes, performance improvements, etc.
 - Minor version: New features, new commands.
 - Major version: Major breaking changes, change of interface, backward incompatible changes
 
 Version need to be updated in following files (Use search and replace all):
+
 - [internal/version.go line 3](./internal/version.go#L3)
 - [CHANGE_LOGS.md line 3](./CHANGE_LOGS.md#L3) [You need to add your own, don't delete the existing one]
 
 ### Contributors
+
 - [Cyrus Mobini (@cyrus2281)](https://github.com/cyrus2281)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ sudo chmod 755 /usr/local/bin/g
 Move-Item -Force -Path .\g-win-vX.X.X.exe -Destination C:\Windows\System32\g.exe
 ```
 
-3. Ensure the binary has the correct permissions (by default, the permissions are set to `Everyone: (RX)`)
-
-```powershell
-icacls C:\Windows\System32\g.exe /grant 'Everyone:(RX)'
-```
-
 ## Auto-Completion
 
 For auto-completion, you can run the following commands based on your shell:
@@ -127,12 +121,6 @@ sudo mkdir -p ${fpath[1]} && sudo touch ${fpath[1]}/_g && USER=$(whoami); sudo c
 ```
 
 ### Windows PowerShell
-
-Add the following to your PowerShell profile file (`$PROFILE`):
-
-```powershell
-g completion powershell | Out-String | Invoke-Expression
-```
 
 For default PowerShell profile file, run the following command:
 
@@ -166,31 +154,31 @@ echo "function prompt { g _ps }" >> $PROFILE
 A bash tool to facilitate managing git branches with long cryptic names with aliases
 
 Usage:
-g [command]
+  g [command]
 
 Available Commands:
-addAlias Adds alias and note to a branch that is not stored yet
-completion Generate the autocompletion script for the specified shell
-create Creates a branch with name, alias, and note, and checks into it
-currentBranch Returns the name of active branch with alias and note
-delete Deletes listed branches base on name or alias
-getBranchAlias Gets the branch alias
-getHome Get the gitBranchTool's home directory path
-help Help about any command
-list Lists all branches with their name, alias, and notes
-removeEntry Removes a registered branch entry without deleting the branch
-rename Updates the alias for the given branch name
-resolveAlias Resolves the branch name from an alias
-set Set configuration options (Run `g set --help` for more information)  
- switch Switches to the branch with the given name or alias
-updateBranchNote Adds/updates the notes for a branch base on name/alias
-updateCheck Checks if a newer version is available
+  addAlias         Adds alias and note to a branch that is not stored yet
+  completion       Generate the autocompletion script for the specified shell
+  create           Creates a branch with name, alias, and note, and checks into it
+  currentBranch    Returns the name of active branch with alias and note
+  delete           Deletes listed branches base on name or alias
+  getBranchAlias   Gets the branch alias
+  getHome          Get the gitBranchTool's home directory path
+  help             Help about any command
+  list             Lists all branches with their name, alias, and notes
+  removeEntry      Removes a registered branch entry without deleting the branch
+  rename           Updates the alias for the given branch name
+  resolveAlias     Resolves the branch name from an alias
+  set              Set configuration options (Run `g set --help` for more information)
+  switch           Switches to the branch with the given name or alias
+  updateBranchNote Adds/updates the notes for a branch base on name/alias
+  updateCheck      Checks if a newer version is available
 
 Flags:
--h, --help help for g
--N, --no-log no logs
--V, --verbose verbose output
--v, --version version for g
+  -h, --help      help for g
+  -N, --no-log    no logs
+  -V, --verbose   verbose output
+  -v, --version   version for g
 
 Use "g [command] --help" for more information about a command.
 ```
@@ -231,6 +219,12 @@ g d banner
 
 ```bash
 g d banner cyrus/jira-50930
+```
+
+- **Set branch name prefix for current repository**
+
+```bash
+g set local-prefix dev/
 ```
 
 - **Upgrade the tool to latest version**

--- a/cmd/addAlias.go
+++ b/cmd/addAlias.go
@@ -17,7 +17,11 @@ var addAliasCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(2),
 	Aliases: []string{"a"},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return internal.GetGitBranches()
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetGitBranches()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -19,6 +19,9 @@ var createCmd = &cobra.Command{
 	`,
 	Aliases: []string{"c"},
 	Args:    cobra.MinimumNArgs(2),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
 		alias := args[1]

--- a/cmd/currentBranch.go
+++ b/cmd/currentBranch.go
@@ -17,6 +17,9 @@ var currentBranchCmd = &cobra.Command{
 	Short:   "Returns the name of active branch with alias and note",
 	Long:    `Returns the name of active branch with alias and note`,
 	Aliases: []string{"current-branch", "cb"},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		git := internal.Git{}
 		if !git.IsGitRepo() {

--- a/cmd/getBranchAlias.go
+++ b/cmd/getBranchAlias.go
@@ -17,7 +17,14 @@ var getBranchAliasCmd = &cobra.Command{
 	Short:   "Gets the branch alias",
 	Long:    `Gets the branch alias`,
 	Args:    cobra.ExactArgs(1),
-	Aliases: []string{"get-branch-alias", "g"},
+	Aliases: []string{"get-branch-alias", "gbr"},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetBranches()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		git := internal.Git{}
 		if !git.IsGitRepo() {

--- a/cmd/getHome.go
+++ b/cmd/getHome.go
@@ -19,6 +19,9 @@ var getHomeCmd = &cobra.Command{
 	Short:   "Get the gitBranchTool's home directory path",
 	Long:    `Get the gitBranchTool's home directory path`,
 	Aliases: []string{"get-home", "home", "gh"},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,6 +16,9 @@ var listCmd = &cobra.Command{
 	Short:   "Lists all branches with their name, alias, and notes",
 	Long:    `Lists all branches with their name, alias, and notes`,
 	Aliases: []string{"ls", "l"},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		repoBranches := internal.GetRepositoryBranches()
 		internal.PrintTableHeader()

--- a/cmd/promptString.go
+++ b/cmd/promptString.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"runtime"
 	"strings"
 
 	"github.com/cyrus2281/gitBranchTool/internal"
@@ -20,18 +21,26 @@ var promptStringCmd = &cobra.Command{
 	Long:   `Returns the prompt string - used for the custom prompt`,
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		username := os.Getenv("LOGNAME")
-		currentUser, err := user.Current()
-		if err == nil {
-			username = currentUser.Username
+		prompt := ""
+		if runtime.GOOS == "windows" {
+			username := os.Getenv("USERNAME")
+			prompt = fmt.Sprintf("%s / %s # ", username, getPrompt(" > "))
+		} else {
+			username := os.Getenv("LOGNAME")
+			if username == "" {
+				currentUser, err := user.Current()
+				if err == nil {
+					username = currentUser.Username
+				}
+			}
+			prompt = fmt.Sprintf("%s ➤ %s ❖ ", username, getPrompt(" ⌥ "))
 		}
-		prompt := fmt.Sprintf("%s ➤ %s ❖ ", username, getPrompt())
 		fmt.Print(prompt)
 	},
 }
 
 // Build the custom prompt string
-func getPrompt() string {
+func getPrompt(separator string) string {
 	workingDirectory, err := os.Getwd()
 	if err != nil {
 		return "$"
@@ -69,7 +78,7 @@ func getPrompt() string {
 	}
 
 	// Custom Prompt String
-	return fmt.Sprintf("%s%s ⌥ %s", repo, subpath, currentBranch)
+	return repo + subpath + separator + currentBranch
 }
 
 func init() {

--- a/cmd/removeEntry.go
+++ b/cmd/removeEntry.go
@@ -15,6 +15,13 @@ var removeEntryCmd = &cobra.Command{
 	Short:   "Removes a registered branch entry without deleting the branch",
 	Long:    `Removes a registered branch entry without deleting the branch",`,
 	Aliases: []string{"remove-entry", "re"},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetBranchesAndAliases()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		git := internal.Git{}
 		if !git.IsGitRepo() {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -17,7 +17,11 @@ var renameCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(2),
 	Aliases: []string{"mv", "updateBranchAlias", "update-branch-alias", "uba"},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return internal.GetBranches()
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetBranches()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		git := internal.Git{}

--- a/cmd/resolveAlias.go
+++ b/cmd/resolveAlias.go
@@ -21,7 +21,11 @@ var resolveAliasCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Aliases: []string{"resolve-alias", "r"},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return internal.GetAliases()
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetAliases()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		git := internal.Git{}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -27,8 +27,12 @@ Default is nothing (Run command with no argument to remove prefix)
 	Example: g set global-prefix feature/
 `,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		position := len(args) + 1
 		commands := []string{"default-branch", "local-prefix", "global-prefix"}
-		return commands, cobra.ShellCompDirectiveNoFileComp
+		if position == 1 {
+			return commands, cobra.ShellCompDirectiveNoFileComp
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -22,7 +22,11 @@ For example:
 	Args:    cobra.MinimumNArgs(1),
 	Aliases: []string{"checkout", "check", "s"},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return internal.GetAllBranchesAndAliases()
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetAllBranchesAndAliases()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		git := internal.Git{}

--- a/cmd/updateBranchNote.go
+++ b/cmd/updateBranchNote.go
@@ -16,7 +16,11 @@ var updateBranchNoteCmd = &cobra.Command{
 	Long:  `Adds/updates the notes for a branch base on name/alias`,
 	Args:  cobra.MinimumNArgs(2),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return internal.GetBranchesAndAliases()
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetBranchesAndAliases()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	Aliases: []string{"update-branch-note", "ubn"},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/updateCheck.go
+++ b/cmd/updateCheck.go
@@ -25,6 +25,9 @@ var updateCheckCmd = &cobra.Command{
 	Short:   "Checks if a newer version is available",
 	Long:    `Checks if a newer version is available. Asks to upgrade if available",`,
 	Aliases: []string{"update-check", "uc"},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		yesToAll, _ := cmd.Flags().GetBool("yes-to-all")
 		checkVersionAndUpdate(yesToAll)

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const VERSION = "3.0.7"
+const VERSION = "3.0.8"

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const VERSION = "3.0.8"
+const VERSION = "3.0.6"


### PR DESCRIPTION
This pull request adds support for PowerShell Custom Prompt and fixes an issue with completion repetition. The `promptStringCmd` command has been added to return the custom prompt string for the PowerShell environment. The `getPrompt` function has been modified to include the separator based on the operating system. Additionally, the `ValidArgsFunction` has been updated in multiple commands to handle different positions of arguments and return the appropriate completion directives.

closes #18