### PR TITLE
Add remote branch deletion support to delete command

### DIFF
--- a/CHANGE_LOGS.md
+++ b/CHANGE_LOGS.md
@@ -1,5 +1,8 @@
 # Version Change Logs
 
+### Version 3.1.2
+> Added remote branch deletion support for the delete command
+
 ### Version 3.1.1
 > Fixed the bug where the tool config was not being automatically created
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -31,6 +31,8 @@ var deleteCmd = &cobra.Command{
 		itemsToDelete := args
 		safeDelete, _ := cmd.Flags().GetBool("safe-delete")
 		ignoreErrors, _ := cmd.Flags().GetBool("ignore-errors")
+		remote, _ := cmd.Flags().GetBool("remote")
+		remoteOnly, _ := cmd.Flags().GetBool("remote-only")
 		repoBranches := internal.GetRepositoryBranches()
 
 		for _, item := range itemsToDelete {
@@ -39,14 +41,25 @@ var deleteCmd = &cobra.Command{
 				logger.InfoF("Branch/Alias \"%v\" not found\n", item)
 				continue
 			}
-			err := git.DeleteBranch(branch.Name, !safeDelete)
-			if err != nil {
-				logger.WarningF("Failed to delete branch \"%v\", %v\n", branch.Name, err)
-			}
+			var err error
+			if !remoteOnly {
+				err = git.DeleteBranch(branch.Name, !safeDelete)
+				if err != nil {
+					logger.WarningF("Failed to delete branch \"%v\", %v\n", branch.Name, err)
+				}
 
-			if err == nil || ignoreErrors {
-				repoBranches.RemoveBranch(branch)
-				logger.InfoF("Branch \"%v\" with alias \"%v\" was deleted\n", branch.Name, branch.Alias)
+				if err == nil || ignoreErrors {
+					repoBranches.RemoveBranch(branch)
+					logger.InfoF("Branch \"%v\" with alias \"%v\" was deleted\n", branch.Name, branch.Alias)
+				}
+			}
+			if (err == nil || ignoreErrors) && (remote || remoteOnly) {
+				err = git.DeleteRemoteBranch(branch.Name)
+				if err != nil {
+					logger.WarningF("Failed to delete remote branch \"%v\", %v\n", branch.Name, err)
+				} else {
+					logger.InfoF("Remote branch \"%v\" was deleted\n", branch.Name)
+				}
 			}
 		}
 	},
@@ -56,4 +69,6 @@ func init() {
 	rootCmd.AddCommand(deleteCmd)
 	deleteCmd.Flags().BoolP("safe-delete", "s", false, "Safe delete branches - prevents deleting unmerged branches")
 	deleteCmd.Flags().BoolP("ignore-errors", "i", false, "Ignore if git command fails and proceeds to remove the alias from the repository")
+	deleteCmd.Flags().BoolP("remote", "r", false, "Delete the remote branch as well")
+	deleteCmd.Flags().Bool("remote-only", false, "Deletes only the remote branch. Local branch and registry entry are not removed")
 }

--- a/internal/git.go
+++ b/internal/git.go
@@ -92,6 +92,11 @@ func (g *Git) DeleteBranch(name string, force bool) error {
 	}
 }
 
+func (g *Git) DeleteRemoteBranch(name string) error {
+	_, err := runCommand([]string{"git", "push", "origin", "--delete", name})
+	return err
+}
+
 func (g *Git) SwitchBranch(name string) error {
 	_, err := runCommand([]string{"git", "checkout", name})
 	return err

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const VERSION = "3.1.1"
+const VERSION = "3.1.2"


### PR DESCRIPTION
Introduce functionality to delete remote branches through the delete command, enhancing branch management capabilities. Update version to 3.1.2 to reflect this addition.