### PR TITLE
fix: Refactor print statements to use unified PrintTable function

### DIFF
--- a/cmd/currentBranch.go
+++ b/cmd/currentBranch.go
@@ -4,8 +4,6 @@ Copyright © 2024 Cyrus Mobini
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/cyrus2281/gitBranchTool/internal"
 	"github.com/cyrus2281/go-logger"
 	"github.com/spf13/cobra"
@@ -34,8 +32,9 @@ var currentBranchCmd = &cobra.Command{
 		if !ok {
 			logger.FatalF("Branch \"%v\" is not registered\n", currentBranch)
 		}
-		internal.PrintTableHeader()
-		fmt.Println(branch.String())
+		headers := []string{"Branch Name", "Alias", "Note"}
+		rows := [][]string{{branch.Name, branch.Alias, branch.Note}}
+		internal.PrintTable(headers, rows)
 	},
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -4,10 +4,7 @@ Copyright © 2024 Cyrus Mobini
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/cyrus2281/gitBranchTool/internal"
-	"github.com/cyrus2281/go-logger"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +33,6 @@ var listCmd = &cobra.Command{
 			if branchName == "" {
 				continue
 			}
-			// Check if this worktree has a stored alias
 			wt, ok := repoBranches.GetWorktreeByPath(path)
 			if ok {
 				branchToWorktreeInfo[branchName] = wt.Alias
@@ -55,18 +51,19 @@ var listCmd = &cobra.Command{
 		}
 
 		if hasWorktrees {
-			internal.PrintBranchTableHeaderWithWorktree()
-			for index, branch := range branches {
-				wtInfo := branchToWorktreeInfo[branch.Name]
-				logger.InfoF("%d) ", index)
-				fmt.Printf("%-20s\t%-20s\t%-20s\t%-15s\n", branch.Name, branch.Alias, branch.Note, wtInfo)
+			headers := []string{"Branch Name", "Alias", "Note", "Worktree"}
+			rows := make([][]string, len(branches))
+			for i, branch := range branches {
+				rows[i] = []string{branch.Name, branch.Alias, branch.Note, branchToWorktreeInfo[branch.Name]}
 			}
+			internal.PrintTable(headers, rows)
 		} else {
-			internal.PrintTableHeader()
-			for index, branch := range branches {
-				logger.InfoF("%d) ", index)
-				fmt.Println(branch.String())
+			headers := []string{"Branch Name", "Alias", "Note"}
+			rows := make([][]string, len(branches))
+			for i, branch := range branches {
+				rows[i] = []string{branch.Name, branch.Alias, branch.Note}
 			}
+			internal.PrintTable(headers, rows)
 		}
 	},
 }

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -57,8 +57,8 @@ var worktreeCmd = &cobra.Command{
 		storedWorktrees := repoBranches.GetWorktrees()
 		shownPaths := make(map[string]bool)
 
-		internal.PrintWorktreeTableHeader()
-		index := 0
+		headers := []string{"Path", "Alias", "Branch", "Branch Alias", "Note"}
+		rows := [][]string{}
 
 		for _, wt := range storedWorktrees {
 			branch := worktreeMap[wt.Path]
@@ -69,10 +69,8 @@ var worktreeCmd = &cobra.Command{
 					branchAlias = b.Alias
 				}
 			}
-			logger.InfoF("%d) ", index)
-			fmt.Println(wt.StringWithBranch(branch, branchAlias))
+			rows = append(rows, []string{wt.Path, wt.Alias, branch, branchAlias, wt.Note})
 			shownPaths[wt.Path] = true
-			index++
 		}
 
 		for path, branch := range worktreeMap {
@@ -86,11 +84,10 @@ var worktreeCmd = &cobra.Command{
 					branchAlias = b.Alias
 				}
 			}
-			unregistered := internal.Worktree{Path: path}
-			logger.InfoF("%d) ", index)
-			fmt.Println(unregistered.StringWithBranch(branch, branchAlias))
-			index++
+			rows = append(rows, []string{path, "", branch, branchAlias, ""})
 		}
+
+		internal.PrintTable(headers, rows)
 	},
 }
 

--- a/cmd/worktreeList.go
+++ b/cmd/worktreeList.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/cyrus2281/gitBranchTool/internal"
 	"github.com/cyrus2281/go-logger"
 	"github.com/spf13/cobra"
@@ -35,14 +33,12 @@ var worktreeListCmd = &cobra.Command{
 
 		repoBranches := internal.GetRepositoryBranches()
 		storedWorktrees := repoBranches.GetWorktrees()
-
-		// Build a set of paths we've already shown from stored worktrees
 		shownPaths := make(map[string]bool)
 
-		internal.PrintWorktreeTableHeader()
-		index := 0
+		headers := []string{"Path", "Alias", "Branch", "Branch Alias", "Note"}
+		rows := [][]string{}
 
-		// First show stored worktrees (these have alias/note)
+		// First add stored worktrees (these have alias/note)
 		for _, wt := range storedWorktrees {
 			branch := worktreeMap[wt.Path]
 			branchAlias := ""
@@ -52,13 +48,11 @@ var worktreeListCmd = &cobra.Command{
 					branchAlias = b.Alias
 				}
 			}
-			logger.InfoF("%d) ", index)
-			fmt.Println(wt.StringWithBranch(branch, branchAlias))
+			rows = append(rows, []string{wt.Path, wt.Alias, branch, branchAlias, wt.Note})
 			shownPaths[wt.Path] = true
-			index++
 		}
 
-		// Then show unregistered worktrees from git
+		// Then add unregistered worktrees from git
 		for path, branch := range worktreeMap {
 			if shownPaths[path] {
 				continue
@@ -70,15 +64,10 @@ var worktreeListCmd = &cobra.Command{
 					branchAlias = b.Alias
 				}
 			}
-			unregistered := internal.Worktree{
-				Alias: "",
-				Path:  path,
-				Note:  "",
-			}
-			logger.InfoF("%d) ", index)
-			fmt.Println(unregistered.StringWithBranch(branch, branchAlias))
-			index++
+			rows = append(rows, []string{path, "", branch, branchAlias, ""})
 		}
+
+		internal.PrintTable(headers, rows)
 	},
 }
 

--- a/internal/common.go
+++ b/internal/common.go
@@ -1,8 +1,10 @@
 package internal
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cyrus2281/go-logger"
 	"github.com/spf13/viper"
@@ -56,19 +58,70 @@ func GetRepositoryBranches() RepositoryBranches {
 	return repoBranches
 }
 
-func PrintTableHeader() {
-	logger.InfoF("   %-20s\t%-20s\t%-20s\n", "Branch Name", "Alias", "Note")
-	logger.Infoln("------------------------------------------------------------")
-}
+// PrintTable prints a formatted table with dynamic column widths.
+// Headers define column names, rows contain the data.
+// Row numbering (0), 1), ...) is added automatically.
+func PrintTable(headers []string, rows [][]string) {
+	colCount := len(headers)
 
-func PrintBranchTableHeaderWithWorktree() {
-	logger.InfoF("   %-20s\t%-20s\t%-20s\t%-15s\n", "Branch Name", "Alias", "Note", "Worktree")
-	logger.Infoln("-------------------------------------------------------------------------------")
-}
+	// Compute max width per column from headers and data
+	widths := make([]int, colCount)
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i := 0; i < colCount && i < len(row); i++ {
+			if len(row[i]) > widths[i] {
+				widths[i] = len(row[i])
+			}
+		}
+	}
 
-func PrintWorktreeTableHeader() {
-	logger.InfoF("   %-40s\t%-15s\t%-25s\t%-15s\t%-20s\n", "Path", "Alias", "Branch", "Branch Alias", "Note")
-	logger.Infoln("------------------------------------------------------------------------------------------------------------------------------")
+	// Compute index prefix width (e.g. "0) " = 3, "10) " = 4)
+	indexWidth := 3
+	if len(rows) >= 10 {
+		indexWidth = len(fmt.Sprintf("%d) ", len(rows)-1))
+	}
+	padding := 3
+
+	// Print header
+	fmt.Printf("%s", strings.Repeat(" ", indexWidth))
+	for i, h := range headers {
+		if i < colCount-1 {
+			fmt.Printf("%-*s%s", widths[i], h, strings.Repeat(" ", padding))
+		} else {
+			fmt.Printf("%s", h)
+		}
+	}
+	fmt.Println()
+
+	// Print separator
+	totalWidth := indexWidth
+	for i, w := range widths {
+		totalWidth += w
+		if i < colCount-1 {
+			totalWidth += padding
+		}
+	}
+	fmt.Println(strings.Repeat("-", totalWidth))
+
+	// Print rows
+	for idx, row := range rows {
+		prefix := fmt.Sprintf("%d) ", idx)
+		fmt.Printf("%-*s", indexWidth, prefix)
+		for i := 0; i < colCount; i++ {
+			cell := ""
+			if i < len(row) {
+				cell = row[i]
+			}
+			if i < colCount-1 {
+				fmt.Printf("%-*s%s", widths[i], cell, strings.Repeat(" ", padding))
+			} else {
+				fmt.Printf("%s", cell)
+			}
+		}
+		fmt.Println()
+	}
 }
 
 func GetWorktreePath() string {


### PR DESCRIPTION
This pull request refactors the way tables are printed in the CLI output for branch and worktree commands, replacing multiple custom table header and row printing functions with a single, reusable `PrintTable` function. This change makes the code more maintainable and ensures consistent formatting across all commands. Additionally, it removes unnecessary imports and cleans up related code.

Key improvements include:

**Unified Table Rendering:**

* Introduced a new `PrintTable` function in `internal/common.go` that dynamically formats tables with headers and rows, automatically handling column widths and row numbering. This replaces the previous custom header and row printing logic.
* Updated the `currentBranch`, `list`, `worktree`, and `worktreeList` commands to use the new `PrintTable` function for displaying output, improving consistency and reducing code duplication. [[1]](diffhunk://#diff-f01efbbd095b552899f55ec22a93931d8dd0c91f17fdc04f0f3e88d2924b30f1L37-R37) [[2]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L58-R66) [[3]](diffhunk://#diff-8c39bfdd584ed7b0cb8e47fdfa14df1aeba4345d6778475127cf868ed2c029f1L60-R61) [[4]](diffhunk://#diff-8c39bfdd584ed7b0cb8e47fdfa14df1aeba4345d6778475127cf868ed2c029f1L72-L75) [[5]](diffhunk://#diff-8c39bfdd584ed7b0cb8e47fdfa14df1aeba4345d6778475127cf868ed2c029f1L89-R90) [[6]](diffhunk://#diff-2964baa695072fdc33ccc7e04754da35d5373ee96f0e601dcad266121ccbc4faL38-R41) [[7]](diffhunk://#diff-2964baa695072fdc33ccc7e04754da35d5373ee96f0e601dcad266121ccbc4faL55-R55) [[8]](diffhunk://#diff-2964baa695072fdc33ccc7e04754da35d5373ee96f0e601dcad266121ccbc4faL73-R70)

**Code Cleanup:**

* Removed now-unnecessary table header functions (`PrintTableHeader`, `PrintBranchTableHeaderWithWorktree`, `PrintWorktreeTableHeader`) from `internal/common.go`.
* Removed unused imports (such as `fmt` and `logger`) from several command files, further simplifying the codebase. [[1]](diffhunk://#diff-f01efbbd095b552899f55ec22a93931d8dd0c91f17fdc04f0f3e88d2924b30f1L7-L8) [[2]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L7-L10) [[3]](diffhunk://#diff-2964baa695072fdc33ccc7e04754da35d5373ee96f0e601dcad266121ccbc4faL4-L5) [[4]](diffhunk://#diff-630d21b610ac56c4c88441e1ea512dba613ef29c34896aa9db7ddee6f6d1899cR4-R7)

**Minor Improvements:**

* Cleaned up comments and removed redundant code in the command handlers, making the logic clearer and easier to follow. [[1]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L39) [[2]](diffhunk://#diff-2964baa695072fdc33ccc7e04754da35d5373ee96f0e601dcad266121ccbc4faL38-R41) [[3]](diffhunk://#diff-2964baa695072fdc33ccc7e04754da35d5373ee96f0e601dcad266121ccbc4faL55-R55)

These changes result in a more maintainable and consistent CLI output across the application.…better table formatting