### PR TITLE
fix: log git commands in verbose mode

### DIFF
--- a/internal/git.go
+++ b/internal/git.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/cyrus2281/go-logger"
 )
 
 var gitCommands = map[string][]string{
@@ -15,6 +17,7 @@ var gitCommands = map[string][]string{
 }
 
 func runCommand(command []string) (string, error) {
+	logger.Debugln("Running:", strings.Join(command, " "))
 	// Run the command
 	cmd := exec.Command(command[0], command[1:]...)
 


### PR DESCRIPTION
## Summary
- Adds debug logging of the actual git commands being executed in the centralized `runCommand` function
- When `-V` (verbose) flag is used, all git commands are now printed before execution

## Test plan
- [ ] Run any command with `-V` flag and verify git commands are logged (e.g. `gbt switch myBranch -V`)
- [ ] Run without `-V` and verify no extra output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)