### PR TITLE
fix: Register branch with alias after successful worktree creation

### DIFF
--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -117,16 +117,6 @@ func executeSwitch(git *internal.Git, repoBranches *internal.RepositoryBranches,
 			}
 		}
 
-		if !branchRegistered && hasAlias {
-			newBranch := internal.Branch{Name: branchName, Alias: alias, Note: notes}
-			if !repoBranches.AliasExists(alias) {
-				repoBranches.AddBranch(newBranch)
-				logger.InfoF("Branch \"%s\" has been registered with alias \"%s\"\n", branchName, alias)
-			} else {
-				logger.WarningF("Alias \"%s\" already exists. Branch was not registered.\n", alias)
-			}
-		}
-
 		if repoBranches.WorktreeAliasExists(wtAlias) {
 			logger.FatalF("Worktree alias \"%s\" already exists. Alias must be unique.\n", wtAlias)
 		}
@@ -136,6 +126,17 @@ func executeSwitch(git *internal.Git, repoBranches *internal.RepositoryBranches,
 		err = git.WorktreeAdd(resolvedPath, branchName)
 		if err != nil {
 			logger.Fatalln("Failed to create worktree:", err)
+		}
+
+		// Register the branch after successful worktree creation
+		if !branchRegistered && hasAlias {
+			newBranch := internal.Branch{Name: branchName, Alias: alias, Note: notes}
+			if !repoBranches.AliasExists(alias) {
+				repoBranches.AddBranch(newBranch)
+				logger.InfoF("Branch \"%s\" has been registered with alias \"%s\"\n", branchName, alias)
+			} else {
+				logger.WarningF("Alias \"%s\" already exists. Branch was not registered.\n", alias)
+			}
 		}
 
 		newWorktree := internal.Worktree{Alias: wtAlias, Path: resolvedPath, Note: notes}

--- a/cmd/switch_test.go
+++ b/cmd/switch_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -135,5 +136,105 @@ func TestExecuteSwitch_WorktreeMode_CreateNew(t *testing.T) {
 	wtPath := filepath.Join(repoDir, "worktrees", "new-wt-alias")
 	if _, err := os.Stat(wtPath); os.IsNotExist(err) {
 		t.Error("worktree directory should exist")
+	}
+}
+
+// TestSwitchSubprocessHelper is invoked as a subprocess by the fail tests below.
+// It calls executeSwitch directly so we can observe os.Exit from logger.Fatalln.
+func TestSwitchSubprocessHelper(t *testing.T) {
+	if os.Getenv("SWITCH_TEST_SUBPROCESS") != "1" {
+		t.Skip("subprocess helper — invoked by fail tests")
+	}
+
+	repoDir := os.Getenv("SWITCH_TEST_REPO_DIR")
+	storeDir := os.Getenv("SWITCH_TEST_STORE_DIR")
+	os.Chdir(repoDir)
+
+	store := &internal.RepositoryBranches{
+		RepositoryName: filepath.Base(repoDir),
+		StoreDirectory: storeDir,
+	}
+	git := &internal.Git{}
+
+	var opts switchOpts
+	if os.Getenv("SWITCH_TEST_WORKTREE") == "1" {
+		repoPath, _ := git.GetRepositoryPath()
+		opts = switchOpts{
+			UseWorktree:          true,
+			WorktreePathTemplate: "./worktrees/{alias}",
+			RepoPath:             repoPath,
+			RepoName:             filepath.Base(repoDir),
+		}
+	}
+
+	executeSwitch(git, store,
+		os.Getenv("SWITCH_TEST_ID"),
+		os.Getenv("SWITCH_TEST_ALIAS"),
+		"",
+		opts,
+	)
+}
+
+// TestExecuteSwitch_FailNoRegister verifies that a failed branch switch
+// (nonexistent branch) does not register the branch in the store.
+func TestExecuteSwitch_FailNoRegister(t *testing.T) {
+	repoDir := initTestRepo(t)
+	storeDir := t.TempDir()
+	storeDir, _ = filepath.EvalSymlinks(storeDir)
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSwitchSubprocessHelper$")
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(),
+		"SWITCH_TEST_SUBPROCESS=1",
+		"SWITCH_TEST_REPO_DIR="+repoDir,
+		"SWITCH_TEST_STORE_DIR="+storeDir,
+		"SWITCH_TEST_ID=nonexistent-branch",
+		"SWITCH_TEST_ALIAS=nb",
+	)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected switch to nonexistent branch to fail")
+	}
+
+	store := &internal.RepositoryBranches{
+		RepositoryName: filepath.Base(repoDir),
+		StoreDirectory: storeDir,
+	}
+	if len(store.GetBranches()) != 0 {
+		t.Errorf("expected 0 branches after failed switch, got %d", len(store.GetBranches()))
+	}
+}
+
+// TestExecuteSwitch_WorktreeMode_FailNoRegister verifies that a failed worktree
+// creation (nonexistent branch) registers neither branch nor worktree.
+func TestExecuteSwitch_WorktreeMode_FailNoRegister(t *testing.T) {
+	repoDir := initTestRepo(t)
+	storeDir := t.TempDir()
+	storeDir, _ = filepath.EvalSymlinks(storeDir)
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSwitchSubprocessHelper$")
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(),
+		"SWITCH_TEST_SUBPROCESS=1",
+		"SWITCH_TEST_REPO_DIR="+repoDir,
+		"SWITCH_TEST_STORE_DIR="+storeDir,
+		"SWITCH_TEST_ID=nonexistent-branch",
+		"SWITCH_TEST_ALIAS=nb",
+		"SWITCH_TEST_WORKTREE=1",
+	)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected worktree creation for nonexistent branch to fail")
+	}
+
+	store := &internal.RepositoryBranches{
+		RepositoryName: filepath.Base(repoDir),
+		StoreDirectory: storeDir,
+	}
+	if len(store.GetBranches()) != 0 {
+		t.Errorf("expected 0 branches after failed worktree creation, got %d", len(store.GetBranches()))
+	}
+	if len(store.GetWorktrees()) != 0 {
+		t.Errorf("expected 0 worktrees after failed worktree creation, got %d", len(store.GetWorktrees()))
 	}
 }

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const VERSION = "3.2.5"
+const VERSION = "3.2.6"


### PR DESCRIPTION
This pull request improves the branch and worktree registration logic in the `switch` command to ensure that branches are only registered after a successful switch or worktree creation, and adds new tests to verify this behavior. It also bumps the version to 3.2.6.

**Switch command logic improvements:**

* Moved the registration of new branches with an alias in `cmd/switch.go` so that branches are only registered after successful worktree creation, preventing branches from being registered if the switch or worktree creation fails. [[1]](diffhunk://#diff-b2ed7e5b038c80cf527054a8193a47892ca7beccb0c8e613f0aec2d7b225f272L120-L129) [[2]](diffhunk://#diff-b2ed7e5b038c80cf527054a8193a47892ca7beccb0c8e613f0aec2d7b225f272R131-R141)

**Testing enhancements:**

* Added subprocess-based tests in `cmd/switch_test.go` to verify that failed branch switches or worktree creations do not register branches or worktrees in the store, including helper logic to simulate failures and check store state. [[1]](diffhunk://#diff-9500d5232198477e4ad23c4683ab4baf489e9925d916423a16e662cbe7123248R5) [[2]](diffhunk://#diff-9500d5232198477e4ad23c4683ab4baf489e9925d916423a16e662cbe7123248R141-R240)

**Version update:**

* Bumped the version in `internal/version.go` from 3.2.5 to 3.2.6.