### PR TITLE
feat: add `g merge` command (#38)

### DIFF
--- a/CHANGE_LOGS.md
+++ b/CHANGE_LOGS.md
@@ -1,12 +1,13 @@
 # Version Change Logs
 
+### Version 3.3.0
+> Add `g merge` command for merging/rebasing branches by alias (#38)
+
 ### Version 3.2.7
 > Register branch with alias after successful worktree creation (#37)
 
 ### Version 3.2.5
 > log git commands in verbose mode (#33)
-
-Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
 ### Version 3.2.4
 > enhance GetRepositoryName to use gitCommonDir for accurate repo name resolution (#32)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Available Commands:
   getBranchAlias   Gets the branch alias
   help             Help about any command
   list             Lists all branches with their name, alias, and notes
+  merge            Merges or rebases the given branch into the current branch
   removeEntry      Removes a registered branch entry without deleting the branch
   rename           Updates the alias for the given branch name
   resolveAlias     Resolves the branch name from an alias
@@ -184,6 +185,30 @@ Flags:
 
 Use "g [command] --help" for more information about a command.
 ```
+
+### Merge
+
+`g merge [NAME/ALIAS]` (alias `g m`) merges — or, with `--rebase`, rebases — the given branch **into the current branch**, resolving the argument through your branch aliases. With **no argument** it uses the configured default branch, making `g merge` a quick way to update the current branch with the latest of `main`.
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `g merge NAME/ALIAS` | `g m NAME/ALIAS` | Merge the given branch into the current branch (`git merge`) |
+| `g merge` | `g m` | Merge the configured default branch into the current branch |
+| `g merge NAME/ALIAS --rebase` | `g m NAME/ALIAS -r` | Rebase the current branch onto the given branch (`git rebase`) |
+| `g merge --continue` / `g merge --abort` | | Continue/abort an in-progress merge or rebase |
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--rebase` | `-r` | Use `git rebase` instead of `git merge` |
+| `--squash` | `-s` | Squash the merged commits (`git merge --squash`; incompatible with `--rebase`) |
+| `--no-verify` | `-n` | Skip git hooks (`git merge --no-verify`; incompatible with `--rebase`) |
+| `--fetch` | `-f` | Fetch the latest of the branch from `origin` before merging/rebasing |
+| `--ff-only` | | Refuse to merge unless it can be fast-forwarded (incompatible with `--rebase`) |
+| `--no-ff` | | Always create a merge commit (incompatible with `--rebase`) |
+| `--abort` | | Abort an in-progress merge or rebase |
+| `--continue` | | Continue an in-progress merge or rebase after resolving conflicts |
+
+When a merge or rebase stops due to conflicts, resolve them and run `g m --continue` to finish, or `g m --abort` to cancel. git's output (conflicts, editor) streams directly to your terminal, so it behaves exactly like running git by hand.
 
 ### Worktrees
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,0 +1,259 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cyrus2281/gitBranchTool/internal"
+	"github.com/cyrus2281/go-logger"
+	"github.com/spf13/cobra"
+)
+
+// mergeCmd represents the merge command
+var mergeCmd = &cobra.Command{
+	Use:   "merge [NAME/ALIAS]",
+	Short: "Merges or rebases the given branch into the current branch",
+	Long: `Merges (or rebases) the branch with the given name or alias into the current branch.
+Uses the git command "git merge NAME" (or "git rebase NAME" with --rebase).
+
+If no name or alias is given, the configured default branch is used. This makes
+"g merge" a quick way to update the current branch with the latest of main.
+
+When a merge or rebase stops due to conflicts, resolve them and run
+"g m --continue" to finish, or "g m --abort" to cancel.
+
+Examples:
+	g merge main            Merge the default/main branch into the current branch
+	g merge feat -r         Rebase the current branch onto the "feat" branch
+	g merge main -f         Fetch origin/main first, then merge it
+	g merge --continue      Continue after resolving conflicts`,
+	Args:    cobra.MaximumNArgs(1),
+	Aliases: []string{"m"},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		position := len(args) + 1
+		if position == 1 {
+			return internal.GetAllBranchesAndAliases()
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		git := internal.Git{}
+		if !git.IsGitRepo() {
+			logger.Fatalln("Not a git repository")
+		}
+
+		opts := mergeOpts{Remote: "origin"}
+		opts.Rebase, _ = cmd.Flags().GetBool("rebase")
+		opts.Squash, _ = cmd.Flags().GetBool("squash")
+		opts.NoVerify, _ = cmd.Flags().GetBool("no-verify")
+		opts.Fetch, _ = cmd.Flags().GetBool("fetch")
+		opts.FFOnly, _ = cmd.Flags().GetBool("ff-only")
+		opts.NoFF, _ = cmd.Flags().GetBool("no-ff")
+		opts.Abort, _ = cmd.Flags().GetBool("abort")
+		opts.Continue, _ = cmd.Flags().GetBool("continue")
+
+		if err := validateMergeOpts(opts, len(args) > 0); err != nil {
+			logger.Fatalln(err)
+		}
+
+		if opts.Abort || opts.Continue {
+			executeMergeState(&git, opts)
+			return
+		}
+
+		repoBranches := internal.GetRepositoryBranches()
+
+		id := ""
+		if len(args) > 0 {
+			id = args[0]
+		} else {
+			id = repoBranches.GetDefaultBranch()
+			logger.InfoF("No branch given; using default branch \"%s\"\n", id)
+		}
+
+		executeMerge(&git, &repoBranches, id, opts)
+	},
+}
+
+type mergeOpts struct {
+	Rebase   bool
+	Squash   bool
+	NoVerify bool
+	Fetch    bool
+	FFOnly   bool
+	NoFF     bool
+	Abort    bool
+	Continue bool
+	Remote   string
+}
+
+// validateMergeOpts enforces the flag-combination rules. It is a pure function
+// (no I/O) so it can be unit-tested directly.
+func validateMergeOpts(opts mergeOpts, hasArg bool) error {
+	if opts.Abort && opts.Continue {
+		return fmt.Errorf("cannot combine --abort and --continue")
+	}
+	if (opts.Abort || opts.Continue) && hasArg {
+		return fmt.Errorf("--abort/--continue do not take a branch argument")
+	}
+	if opts.Rebase {
+		var bad []string
+		if opts.Squash {
+			bad = append(bad, "--squash")
+		}
+		if opts.NoVerify {
+			bad = append(bad, "--no-verify")
+		}
+		if opts.FFOnly {
+			bad = append(bad, "--ff-only")
+		}
+		if opts.NoFF {
+			bad = append(bad, "--no-ff")
+		}
+		if len(bad) > 0 {
+			return fmt.Errorf("--rebase cannot be combined with %s", strings.Join(bad, ", "))
+		}
+	}
+	if opts.FFOnly && opts.NoFF {
+		return fmt.Errorf("cannot combine --ff-only and --no-ff")
+	}
+	return nil
+}
+
+// buildMergeArgs assembles the extra flags passed to "git merge".
+func buildMergeArgs(opts mergeOpts) []string {
+	var args []string
+	if opts.Squash {
+		args = append(args, "--squash")
+	}
+	if opts.NoVerify {
+		args = append(args, "--no-verify")
+	}
+	if opts.FFOnly {
+		args = append(args, "--ff-only")
+	}
+	if opts.NoFF {
+		args = append(args, "--no-ff")
+	}
+	return args
+}
+
+// executeMerge resolves the target branch and performs the merge or rebase.
+func executeMerge(git *internal.Git, repoBranches *internal.RepositoryBranches, id string, opts mergeOpts) {
+	branch, registered := repoBranches.GetBranchByNameOrAlias(id)
+	branchName := id
+	if registered {
+		branchName = branch.Name
+	}
+
+	// Same-branch guard. Skipped when fetching, since fetching the current
+	// branch's remote and merging it is a valid "pull" operation.
+	if !opts.Fetch {
+		if current, err := git.GetCurrentBranch(); err == nil && current == branchName {
+			logger.InfoF("Already on branch \"%s\"; nothing to merge\n", branchName)
+			return
+		}
+	}
+
+	ref := branchName
+	if opts.Fetch {
+		remote := opts.Remote
+		if remote == "" {
+			remote = "origin"
+		}
+		logger.InfoF("Fetching \"%s\" from \"%s\"...\n", branchName, remote)
+		if err := git.Fetch(remote, branchName); err != nil {
+			logger.ErrorF("Failed to fetch \"%s\" from \"%s\"\n", branchName, remote)
+			logger.Fatalln(err)
+		}
+		ref = "FETCH_HEAD"
+	}
+
+	if opts.Rebase {
+		if err := git.RebaseBranch(ref); err != nil {
+			handleIntegrationFailure(git, "rebase", branchName)
+		}
+		logger.InfoF("Rebased the current branch onto \"%s\"\n", branchName)
+		return
+	}
+
+	if err := git.MergeBranch(ref, buildMergeArgs(opts)); err != nil {
+		handleIntegrationFailure(git, "merge", branchName)
+	}
+	if opts.Squash {
+		logger.InfoF("Squash-merged \"%s\". Changes are staged; commit them to finish.\n", branchName)
+		return
+	}
+	logger.InfoF("Merged \"%s\" into the current branch\n", branchName)
+}
+
+// handleIntegrationFailure reports a failed merge/rebase and exits non-zero.
+// When the operation is left in progress it is treated as a conflict and the
+// user is told how to continue or abort.
+func handleIntegrationFailure(git *internal.Git, action, branchName string) {
+	if git.MergeInProgress() || git.RebaseInProgress() {
+		logger.WarningF("Conflicts while trying to %s \"%s\".\n", action, branchName)
+		logger.WarningF("Resolve them, then run \"g m --continue\" (or \"g m --abort\" to cancel).\n")
+		os.Exit(1)
+	}
+	logger.ErrorF("Failed to %s \"%s\"\n", action, branchName)
+	os.Exit(1)
+}
+
+// executeMergeState handles --abort and --continue for an in-progress
+// merge or rebase, auto-detecting which one is running.
+func executeMergeState(git *internal.Git, opts mergeOpts) {
+	rebase := git.RebaseInProgress()
+	merge := git.MergeInProgress()
+	if !rebase && !merge {
+		logger.Fatalln("No merge or rebase in progress")
+	}
+
+	word := "merge"
+	if rebase {
+		word = "rebase"
+	}
+
+	if opts.Abort {
+		var err error
+		if rebase {
+			err = git.RebaseAbort()
+		} else {
+			err = git.MergeAbort()
+		}
+		if err != nil {
+			logger.Fatalln(err)
+		}
+		logger.InfoF("Aborted the in-progress %s\n", word)
+		return
+	}
+
+	// --continue
+	var err error
+	if rebase {
+		err = git.RebaseContinue()
+	} else {
+		err = git.MergeContinue()
+	}
+	if err != nil {
+		if git.MergeInProgress() || git.RebaseInProgress() {
+			logger.WarningF("There are still unresolved conflicts. Resolve them and run \"g m --continue\" again.\n")
+			os.Exit(1)
+		}
+		logger.Fatalln(err)
+	}
+	logger.InfoF("Continued and completed the %s\n", word)
+}
+
+func init() {
+	rootCmd.AddCommand(mergeCmd)
+	mergeCmd.Flags().BoolP("rebase", "r", false, "Use git rebase instead of git merge")
+	mergeCmd.Flags().BoolP("squash", "s", false, "Squash the merged commits (git merge --squash; incompatible with --rebase)")
+	mergeCmd.Flags().BoolP("no-verify", "n", false, "Skip git hooks (git merge --no-verify; incompatible with --rebase)")
+	mergeCmd.Flags().BoolP("fetch", "f", false, "Fetch the latest of the branch from origin before merging/rebasing")
+	mergeCmd.Flags().Bool("ff-only", false, "Refuse to merge unless it can be fast-forwarded (incompatible with --rebase)")
+	mergeCmd.Flags().Bool("no-ff", false, "Always create a merge commit (incompatible with --rebase)")
+	mergeCmd.Flags().Bool("abort", false, "Abort an in-progress merge or rebase")
+	mergeCmd.Flags().Bool("continue", false, "Continue an in-progress merge or rebase after resolving conflicts")
+}

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -1,0 +1,321 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cyrus2281/gitBranchTool/internal"
+)
+
+// runGitIn runs a git command in the given dir and fails the test on error.
+func runGitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{"-C", dir}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %s\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// commitFileIn writes content to file in dir and commits it.
+func commitFileIn(t *testing.T, dir, file, content, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, dir, "add", file)
+	runGitIn(t, dir, "commit", "-m", msg)
+}
+
+func currentBranch(t *testing.T, dir string) string {
+	t.Helper()
+	return strings.TrimSpace(runGitIn(t, dir, "branch", "--show-current"))
+}
+
+func TestValidateMergeOpts(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    mergeOpts
+		hasArg  bool
+		wantErr bool
+	}{
+		{"valid merge", mergeOpts{}, true, false},
+		{"valid rebase", mergeOpts{Rebase: true}, true, false},
+		{"merge squash+noverify", mergeOpts{Squash: true, NoVerify: true}, true, false},
+		{"abort no arg", mergeOpts{Abort: true}, false, false},
+		{"continue no arg", mergeOpts{Continue: true}, false, false},
+		{"abort+continue", mergeOpts{Abort: true, Continue: true}, false, true},
+		{"abort with arg", mergeOpts{Abort: true}, true, true},
+		{"continue with arg", mergeOpts{Continue: true}, true, true},
+		{"rebase+squash", mergeOpts{Rebase: true, Squash: true}, true, true},
+		{"rebase+noverify", mergeOpts{Rebase: true, NoVerify: true}, true, true},
+		{"rebase+ffonly", mergeOpts{Rebase: true, FFOnly: true}, true, true},
+		{"rebase+noff", mergeOpts{Rebase: true, NoFF: true}, true, true},
+		{"ffonly+noff", mergeOpts{FFOnly: true, NoFF: true}, true, true},
+	}
+	for _, c := range cases {
+		err := validateMergeOpts(c.opts, c.hasArg)
+		if (err != nil) != c.wantErr {
+			t.Errorf("%s: wantErr=%v, got %v", c.name, c.wantErr, err)
+		}
+	}
+}
+
+func TestExecuteMerge_MergeByAlias(t *testing.T) {
+	repoDir := initTestRepo(t)
+	def := currentBranch(t, repoDir)
+	runGitIn(t, repoDir, "checkout", "-b", "feature/x")
+	commitFileIn(t, repoDir, "feat.txt", "hi", "feat commit")
+	runGitIn(t, repoDir, "checkout", def)
+	chdir(t, repoDir)
+	t.Setenv("GIT_EDITOR", "true")
+
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "feature/x", Alias: "fx"})
+	git := internal.Git{}
+
+	executeMerge(&git, store, "fx", mergeOpts{})
+
+	if _, err := os.Stat(filepath.Join(repoDir, "feat.txt")); err != nil {
+		t.Errorf("expected feat.txt merged into current branch: %v", err)
+	}
+}
+
+func TestExecuteMerge_Rebase(t *testing.T) {
+	repoDir := initTestRepo(t)
+	def := currentBranch(t, repoDir)
+	runGitIn(t, repoDir, "checkout", "-b", "feature")
+	commitFileIn(t, repoDir, "f.txt", "f", "f commit")
+	runGitIn(t, repoDir, "checkout", def)
+	commitFileIn(t, repoDir, "d.txt", "d", "d commit")
+	runGitIn(t, repoDir, "checkout", "feature")
+	chdir(t, repoDir)
+
+	store := newTestStore(t)
+	git := internal.Git{}
+
+	executeMerge(&git, store, def, mergeOpts{Rebase: true})
+
+	for _, f := range []string{"d.txt", "f.txt"} {
+		if _, err := os.Stat(filepath.Join(repoDir, f)); err != nil {
+			t.Errorf("expected %s present after rebase: %v", f, err)
+		}
+	}
+}
+
+func TestExecuteMerge_Squash(t *testing.T) {
+	repoDir := initTestRepo(t)
+	def := currentBranch(t, repoDir)
+	runGitIn(t, repoDir, "checkout", "-b", "topic")
+	commitFileIn(t, repoDir, "s.txt", "s", "s commit")
+	runGitIn(t, repoDir, "checkout", def)
+	chdir(t, repoDir)
+
+	store := newTestStore(t)
+	git := internal.Git{}
+
+	executeMerge(&git, store, "topic", mergeOpts{Squash: true})
+
+	if _, err := os.Stat(filepath.Join(repoDir, "s.txt")); err != nil {
+		t.Errorf("expected s.txt in working tree after squash: %v", err)
+	}
+	if staged := runGitIn(t, repoDir, "diff", "--cached", "--name-only"); !strings.Contains(staged, "s.txt") {
+		t.Errorf("expected s.txt to be staged, got %q", staged)
+	}
+	if log := runGitIn(t, repoDir, "log", "--oneline"); strings.Contains(log, "s commit") {
+		t.Error("squash should not bring the topic commit into history before commit")
+	}
+}
+
+func TestExecuteMerge_DefaultBranch(t *testing.T) {
+	repoDir := initTestRepo(t)
+	def := currentBranch(t, repoDir)
+	// Branch "work" off the initial commit, then advance the default branch.
+	runGitIn(t, repoDir, "checkout", "-b", "work")
+	runGitIn(t, repoDir, "checkout", def)
+	commitFileIn(t, repoDir, "main-new.txt", "m", "main advance")
+	runGitIn(t, repoDir, "checkout", "work")
+	chdir(t, repoDir)
+	t.Setenv("GIT_EDITOR", "true")
+
+	store := newTestStore(t)
+	store.SetDefaultBranch(def)
+	git := internal.Git{}
+
+	// Simulates the no-arg path in Run: id = store.GetDefaultBranch().
+	executeMerge(&git, store, store.GetDefaultBranch(), mergeOpts{})
+
+	if _, err := os.Stat(filepath.Join(repoDir, "main-new.txt")); err != nil {
+		t.Errorf("expected default branch merged into work: %v", err)
+	}
+}
+
+func TestExecuteMerge_SameBranchGuard(t *testing.T) {
+	repoDir := initTestRepo(t)
+	def := currentBranch(t, repoDir)
+	chdir(t, repoDir)
+
+	store := newTestStore(t)
+	git := internal.Git{}
+
+	before := strings.TrimSpace(runGitIn(t, repoDir, "rev-parse", "HEAD"))
+	executeMerge(&git, store, def, mergeOpts{})
+	after := strings.TrimSpace(runGitIn(t, repoDir, "rev-parse", "HEAD"))
+
+	if before != after {
+		t.Errorf("same-branch guard should not change HEAD: %q -> %q", before, after)
+	}
+}
+
+func TestExecuteMerge_Fetch(t *testing.T) {
+	repoDir := initTestRepo(t)
+	def := currentBranch(t, repoDir)
+
+	remoteDir := t.TempDir()
+	if out, err := exec.Command("git", "init", "--bare", remoteDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare failed: %s\n%s", err, out)
+	}
+	runGitIn(t, repoDir, "remote", "add", "origin", remoteDir)
+
+	// Push topic@topic1, then push topic2, then rewind the local branch so the
+	// remote is strictly ahead of the local tip.
+	runGitIn(t, repoDir, "checkout", "-b", "topic")
+	commitFileIn(t, repoDir, "topic1.txt", "1", "topic1")
+	runGitIn(t, repoDir, "push", "origin", "topic")
+	commitFileIn(t, repoDir, "topic2.txt", "2", "topic2")
+	runGitIn(t, repoDir, "push", "origin", "topic")
+	runGitIn(t, repoDir, "reset", "--hard", "HEAD~1") // local topic now at topic1
+	runGitIn(t, repoDir, "checkout", def)
+	chdir(t, repoDir)
+	t.Setenv("GIT_EDITOR", "true")
+
+	store := newTestStore(t)
+	git := internal.Git{}
+
+	executeMerge(&git, store, "topic", mergeOpts{Fetch: true, Remote: "origin"})
+
+	// topic2.txt only exists on the remote tip; its presence proves we merged
+	// the freshly fetched remote branch rather than the stale local one.
+	if _, err := os.Stat(filepath.Join(repoDir, "topic2.txt")); err != nil {
+		t.Errorf("expected topic2.txt from fetched remote tip: %v", err)
+	}
+}
+
+// setupConflict creates a merge conflict on c.txt between "feature" and the
+// default branch, leaving the repo checked out on the default branch.
+func setupConflict(t *testing.T, repoDir string) string {
+	t.Helper()
+	def := currentBranch(t, repoDir)
+	commitFileIn(t, repoDir, "c.txt", "base\n", "base")
+	runGitIn(t, repoDir, "checkout", "-b", "feature")
+	commitFileIn(t, repoDir, "c.txt", "feature\n", "feature change")
+	runGitIn(t, repoDir, "checkout", def)
+	commitFileIn(t, repoDir, "c.txt", "default\n", "default change")
+	return def
+}
+
+// TestMergeSubprocessHelper is invoked as a subprocess by the exit-path tests
+// below so we can observe os.Exit from a conflict / fatal.
+func TestMergeSubprocessHelper(t *testing.T) {
+	if os.Getenv("MERGE_TEST_SUBPROCESS") != "1" {
+		t.Skip("subprocess helper — invoked by exit-path tests")
+	}
+	repoDir := os.Getenv("MERGE_TEST_REPO_DIR")
+	os.Chdir(repoDir)
+
+	store := &internal.RepositoryBranches{
+		RepositoryName: filepath.Base(repoDir),
+		StoreDirectory: os.Getenv("MERGE_TEST_STORE_DIR"),
+	}
+	git := &internal.Git{}
+
+	opts := mergeOpts{Remote: "origin"}
+	opts.Rebase = os.Getenv("MERGE_TEST_REBASE") == "1"
+	opts.Abort = os.Getenv("MERGE_TEST_ABORT") == "1"
+	opts.Continue = os.Getenv("MERGE_TEST_CONTINUE") == "1"
+
+	if os.Getenv("MERGE_TEST_MODE") == "state" {
+		executeMergeState(git, opts)
+		return
+	}
+	executeMerge(git, store, os.Getenv("MERGE_TEST_ID"), opts)
+}
+
+func TestExecuteMerge_ConflictExitsAndAbort(t *testing.T) {
+	repoDir := initTestRepo(t)
+	setupConflict(t, repoDir)
+	storeDir := t.TempDir()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMergeSubprocessHelper$")
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(),
+		"MERGE_TEST_SUBPROCESS=1",
+		"MERGE_TEST_MODE=merge",
+		"MERGE_TEST_REPO_DIR="+repoDir,
+		"MERGE_TEST_STORE_DIR="+storeDir,
+		"MERGE_TEST_ID=feature",
+		"GIT_EDITOR=true",
+	)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected merge conflict to exit non-zero")
+	}
+
+	chdir(t, repoDir)
+	git := internal.Git{}
+	if !git.MergeInProgress() {
+		t.Fatal("expected merge in progress after conflict")
+	}
+	executeMergeState(&git, mergeOpts{Abort: true})
+	if git.MergeInProgress() {
+		t.Error("expected merge to be aborted")
+	}
+}
+
+func TestExecuteMergeState_Continue(t *testing.T) {
+	repoDir := initTestRepo(t)
+	setupConflict(t, repoDir)
+	chdir(t, repoDir)
+	t.Setenv("GIT_EDITOR", "true")
+
+	git := internal.Git{}
+	if err := git.MergeBranch("feature", nil); err == nil {
+		t.Fatal("expected merge to conflict")
+	}
+	if !git.MergeInProgress() {
+		t.Fatal("expected merge in progress")
+	}
+
+	// Resolve the conflict, then continue.
+	if err := os.WriteFile(filepath.Join(repoDir, "c.txt"), []byte("resolved\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, repoDir, "add", "c.txt")
+
+	executeMergeState(&git, mergeOpts{Continue: true})
+
+	if git.MergeInProgress() {
+		t.Error("expected merge to complete after --continue")
+	}
+}
+
+func TestExecuteMergeState_NothingInProgress(t *testing.T) {
+	repoDir := initTestRepo(t)
+	storeDir := t.TempDir()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMergeSubprocessHelper$")
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(),
+		"MERGE_TEST_SUBPROCESS=1",
+		"MERGE_TEST_MODE=state",
+		"MERGE_TEST_REPO_DIR="+repoDir,
+		"MERGE_TEST_STORE_DIR="+storeDir,
+		"MERGE_TEST_CONTINUE=1",
+	)
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected --continue with nothing in progress to exit non-zero")
+	}
+}

--- a/internal/git.go
+++ b/internal/git.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -32,6 +33,18 @@ func runCommand(command []string) (string, error) {
 
 	// Convert the output to a string and trim any whitespace
 	return strings.TrimSpace(string(output)), nil
+}
+
+// runInteractiveCommand attaches the user's terminal so interactive git
+// operations (commit-message editor, live conflict output) behave like
+// native git, instead of capturing and swallowing their output.
+func runInteractiveCommand(command []string) error {
+	logger.Debugln("Running:", strings.Join(command, " "))
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 type Git struct {
@@ -120,6 +133,79 @@ func (g *Git) DeleteRemoteBranch(name string) error {
 func (g *Git) SwitchBranch(name string) error {
 	_, err := runCommand([]string{"git", "checkout", name})
 	return err
+}
+
+// MergeBranch merges ref into the current branch. opts are extra git merge
+// flags (e.g. --squash, --no-verify, --no-ff). Runs interactively so conflict
+// output and the merge-commit editor work as with native git.
+func (g *Git) MergeBranch(ref string, opts []string) error {
+	command := append([]string{"git", "merge"}, opts...)
+	command = append(command, ref)
+	return runInteractiveCommand(command)
+}
+
+// RebaseBranch rebases the current branch onto ref.
+func (g *Git) RebaseBranch(ref string) error {
+	return runInteractiveCommand([]string{"git", "rebase", ref})
+}
+
+// MergeAbort aborts an in-progress merge.
+func (g *Git) MergeAbort() error {
+	_, err := runCommand([]string{"git", "merge", "--abort"})
+	return err
+}
+
+// MergeContinue continues an in-progress merge after conflicts are resolved.
+func (g *Git) MergeContinue() error {
+	return runInteractiveCommand([]string{"git", "merge", "--continue"})
+}
+
+// RebaseAbort aborts an in-progress rebase.
+func (g *Git) RebaseAbort() error {
+	_, err := runCommand([]string{"git", "rebase", "--abort"})
+	return err
+}
+
+// RebaseContinue continues an in-progress rebase after conflicts are resolved.
+func (g *Git) RebaseContinue() error {
+	return runInteractiveCommand([]string{"git", "rebase", "--continue"})
+}
+
+// Fetch fetches the given branch from the given remote. The fetched tip is
+// available afterwards as FETCH_HEAD.
+func (g *Git) Fetch(remote, branch string) error {
+	return runInteractiveCommand([]string{"git", "fetch", remote, branch})
+}
+
+// GetGitDir returns the path to the git directory for the current worktree.
+// Inside a worktree this is the worktree-specific git dir, which is where
+// merge/rebase state files live.
+func (g *Git) GetGitDir() (string, error) {
+	return runCommand([]string{"git", "rev-parse", "--git-dir"})
+}
+
+// MergeInProgress reports whether a merge is currently in progress.
+func (g *Git) MergeInProgress() bool {
+	gitDir, err := g.GetGitDir()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(gitDir, "MERGE_HEAD"))
+	return err == nil
+}
+
+// RebaseInProgress reports whether a rebase is currently in progress.
+func (g *Git) RebaseInProgress() bool {
+	gitDir, err := g.GetGitDir()
+	if err != nil {
+		return false
+	}
+	for _, name := range []string{"rebase-merge", "rebase-apply"} {
+		if _, err := os.Stat(filepath.Join(gitDir, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // WorktreeAdd creates a worktree for an existing branch

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -446,5 +447,159 @@ func TestGetRepositoryPath(t *testing.T) {
 	resolvedPath, _ := filepath.EvalSymlinks(path)
 	if resolvedPath != resolvedDir {
 		t.Errorf("expected %q, got %q", resolvedDir, resolvedPath)
+	}
+}
+
+// --- merge / rebase / fetch tests ---
+
+// commitFile writes content to file in dir and commits it.
+func commitFile(t *testing.T, dir, file, content, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", file)
+	runGit(t, dir, "commit", "-m", msg)
+}
+
+func TestMergeBranch_FastForward(t *testing.T) {
+	dir := initTestRepo(t)
+	def := strings.TrimSpace(runGit(t, dir, "branch", "--show-current"))
+	runGit(t, dir, "checkout", "-b", "feature")
+	commitFile(t, dir, "feat.txt", "x", "feat commit")
+	runGit(t, dir, "checkout", def)
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	g := Git{}
+	if err := g.MergeBranch("feature", nil); err != nil {
+		t.Fatalf("MergeBranch failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "feat.txt")); err != nil {
+		t.Errorf("expected feat.txt merged into current branch: %v", err)
+	}
+}
+
+func TestRebaseBranch(t *testing.T) {
+	dir := initTestRepo(t)
+	def := strings.TrimSpace(runGit(t, dir, "branch", "--show-current"))
+	runGit(t, dir, "checkout", "-b", "feature")
+	commitFile(t, dir, "f.txt", "f", "f commit")
+	runGit(t, dir, "checkout", def)
+	commitFile(t, dir, "d.txt", "d", "d commit")
+	runGit(t, dir, "checkout", "feature")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	g := Git{}
+	if err := g.RebaseBranch(def); err != nil {
+		t.Fatalf("RebaseBranch failed: %v", err)
+	}
+	for _, f := range []string{"d.txt", "f.txt"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("expected %s present after rebase: %v", f, err)
+		}
+	}
+}
+
+func TestMergeInProgress_AndAbort(t *testing.T) {
+	dir := initTestRepo(t)
+	def := strings.TrimSpace(runGit(t, dir, "branch", "--show-current"))
+	commitFile(t, dir, "c.txt", "base\n", "base")
+	runGit(t, dir, "checkout", "-b", "feature")
+	commitFile(t, dir, "c.txt", "feature\n", "feature change")
+	runGit(t, dir, "checkout", def)
+	commitFile(t, dir, "c.txt", "default\n", "default change")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	g := Git{}
+	if g.MergeInProgress() {
+		t.Error("expected no merge in progress initially")
+	}
+	if err := g.MergeBranch("feature", nil); err == nil {
+		t.Fatal("expected merge to conflict")
+	}
+	if !g.MergeInProgress() {
+		t.Error("expected merge in progress after conflict")
+	}
+	if g.RebaseInProgress() {
+		t.Error("did not expect rebase in progress during a merge")
+	}
+	if err := g.MergeAbort(); err != nil {
+		t.Fatalf("MergeAbort failed: %v", err)
+	}
+	if g.MergeInProgress() {
+		t.Error("expected merge aborted")
+	}
+}
+
+func TestRebaseInProgress_AndAbort(t *testing.T) {
+	dir := initTestRepo(t)
+	def := strings.TrimSpace(runGit(t, dir, "branch", "--show-current"))
+	commitFile(t, dir, "c.txt", "base\n", "base")
+	runGit(t, dir, "checkout", "-b", "feature")
+	commitFile(t, dir, "c.txt", "feature\n", "feature change")
+	runGit(t, dir, "checkout", def)
+	commitFile(t, dir, "c.txt", "default\n", "default change")
+	runGit(t, dir, "checkout", "feature")
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	g := Git{}
+	if err := g.RebaseBranch(def); err == nil {
+		t.Fatal("expected rebase to conflict")
+	}
+	if !g.RebaseInProgress() {
+		t.Error("expected rebase in progress after conflict")
+	}
+	if err := g.RebaseAbort(); err != nil {
+		t.Fatalf("RebaseAbort failed: %v", err)
+	}
+	if g.RebaseInProgress() {
+		t.Error("expected rebase aborted")
+	}
+}
+
+func TestGetGitDir(t *testing.T) {
+	dir := initTestRepo(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	g := Git{}
+	gitDir, err := g.GetGitDir()
+	if err != nil {
+		t.Fatalf("GetGitDir failed: %v", err)
+	}
+	if gitDir == "" {
+		t.Error("expected non-empty git dir")
+	}
+}
+
+func TestFetch(t *testing.T) {
+	remote := initTestRepo(t)
+	def := strings.TrimSpace(runGit(t, remote, "branch", "--show-current"))
+	commitFile(t, remote, "r.txt", "r", "remote commit")
+
+	dir := initTestRepo(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	g := Git{}
+	if err := g.Fetch(remote, def); err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	if got := strings.TrimSpace(runGit(t, dir, "rev-parse", "FETCH_HEAD")); got == "" {
+		t.Error("expected FETCH_HEAD to resolve after fetch")
 	}
 }

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const VERSION = "3.2.7"
+const VERSION = "3.3.0"


### PR DESCRIPTION
## Summary

Closes #38. Adds a new `g merge [Alias|Name]` command (alias `g m`) that merges — or rebases — the given branch **into the current branch**, resolving the argument through the existing branch alias registry. This removes the need to drop back to raw `git` to integrate branches by alias.

Scope was expanded beyond the issue's base flags (per maintainer discussion) to cover the full everyday merge/rebase workflow.

## Behavior

- `g merge NAME/ALIAS` — `git merge` the resolved branch into the current branch.
- `g merge` (no argument) — uses the configured **default branch** (quick "update my branch with main").
- git output (conflicts, editor) **streams live to the terminal**, so it behaves exactly like native git.

### Flags

| Flag | Short | Effect |
|---|---|---|
| `--rebase` | `-r` | Use `git rebase` instead of `git merge` |
| `--squash` | `-s` | `git merge --squash` (incompatible with `--rebase`) |
| `--no-verify` | `-n` | Skip git hooks (incompatible with `--rebase`) |
| `--fetch` | `-f` | Fetch `origin/<branch>` first, then merge/rebase `FETCH_HEAD` |
| `--ff-only` / `--no-ff` | | Merge fast-forward strategy (incompatible with `--rebase`) |
| `--abort` / `--continue` | | Manage an in-progress merge/rebase (auto-detected) |

Validation rejects incompatible combinations (`-r` with `-s`/`-n`/`--ff-only`/`--no-ff`, `--ff-only` with `--no-ff`, `--abort` with `--continue`). Conflicts exit non-zero with guidance to run `g m --continue` / `g m --abort`.

## Implementation

- `internal/git.go`: new `runInteractiveCommand` (inherits stdio for native interactivity) plus `MergeBranch`/`RebaseBranch`/`Fetch`/`*Abort`/`*Continue`/`GetGitDir`/`MergeInProgress`/`RebaseInProgress`.
- `cmd/merge.go`: the command, a pure `validateMergeOpts`, and testable `executeMerge`/`executeMergeState` cores (same structure as `executeSwitch`).
- Version bumped to `3.3.0`; `CHANGE_LOGS.md` and `README.md` updated.

## Testing

- New `cmd/merge_test.go` and extended `internal/git_test.go` (merge, rebase, squash, no-arg default, same-branch guard, fetch-from-remote, conflict exit, abort, continue, validation table). Subprocess-helper pattern used for `os.Exit` paths.
- `go vet ./...` clean; full `go test ./...` passes.
- Manually verified end-to-end with the built binary: FF/non-FF merge, no-arg default, rebase, squash staging, conflict→abort, conflict→resolve→continue, and all validation errors.