### PR TITLE
feat: add `g man` command for an LLM-friendly usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
       - [Worktree Settings](#worktree-settings)
   - [Examples](#examples)
   - [Contributing](#contributing)
+    - [Commit Message Guidelines](#commit-message-guidelines)
     - [Contributors](#contributors)
   - [License](#license)
 
@@ -171,6 +172,7 @@ Available Commands:
   getBranchAlias   Gets the branch alias
   help             Help about any command
   list             Lists all branches with their name, alias, and notes
+  man              Prints an LLM-friendly guide on how to use this tool
   merge            Merges or rebases the given branch into the current branch
   removeEntry      Removes a registered branch entry without deleting the branch
   rename           Updates the alias for the given branch name
@@ -189,6 +191,19 @@ Flags:
 
 Use "g [command] --help" for more information about a command.
 ```
+
+### Manual (LLM Guide)
+
+`g man` (alias `g manual`) prints a concise, LLM-friendly guide describing how to use the tool. It is meant to be dropped into an AI assistant's context so it can drive `g` without reading every `--help` page.
+
+By default it documents only the core commands (`create`, `delete`, `switch`, `merge`, `currentBranch`, `list`, `worktree`) — the minimum needed to be productive. Pass `--full` to document every command instead.
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `g man` | `g manual` | Print the guide for the core commands |
+| `g man --full` | `g man -f` | Print the guide for every command |
+
+The guide is assembled from a short manual that each command carries, and always reminds the reader to run `g <command> --help` for full flag-level details.
 
 ### Merge
 
@@ -399,6 +414,17 @@ If you have any suggestions or issues, please open an issue or a pull request.
 
 In your pull request, please include a description of the changes you made and why you made them, and update the [CHANGE_LOGS.md](./CHANGE_LOGS.md), [VERSION](./VERSION), and [README.md](./README.md) (to contributors section) files accordingly.
 
+### Commit Message Guidelines
+Please use the [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) specification for all commit messages and pull request titles.
+Format your messages as follows: <type>(<scope>): <description>
+
+* feat: A new feature for the user.
+* fix: A bug fix for the user.
+* chore: Routine tasks, maintenance, or dependency updates.
+* docs: Documentation changes only.
+* refactor: Code changes that neither fix a bug nor add a feature.
+
+Example: feat(auth): add google oauth2 login flow
 
 ### Contributors
 

--- a/cmd/addAlias.go
+++ b/cmd/addAlias.go
@@ -13,6 +13,9 @@ var addAliasCmd = &cobra.Command{
 	Long:    `Adds alias and note to a branch that is not stored yet`,
 	Args:    cobra.MinimumNArgs(2),
 	Aliases: []string{"a"},
+	Annotations: map[string]string{
+		manualAnnotation: `Register an ALIAS (and optional NOTE) for an existing branch NAME that is not tracked yet.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -18,6 +18,10 @@ var createCmd = &cobra.Command{
 	`,
 	Aliases: []string{"c"},
 	Args:    cobra.MinimumNArgs(2),
+	Annotations: map[string]string{
+		manualAnnotation: `Create a new git branch, register it under a short ALIAS (with an optional NOTE), and switch to it.
+Flags: -o/--only-create (create without switching), -w/--worktree[=ALIAS] (also create a worktree for the branch).`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/cmd/currentBranch.go
+++ b/cmd/currentBranch.go
@@ -12,6 +12,9 @@ var currentBranchCmd = &cobra.Command{
 	Short:   "Returns the name of active branch with alias and note",
 	Long:    `Returns the name of active branch with alias and note`,
 	Aliases: []string{"current-branch", "cb"},
+	Annotations: map[string]string{
+		manualAnnotation: `Show the active branch's registered name, alias, and note.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,6 +18,10 @@ var deleteCmd = &cobra.Command{
 	With safe-delete uses the git command \"git branch [...NAME|ALIAS] \"`,
 	Args:    cobra.MinimumNArgs(1),
 	Aliases: []string{"del", "d"},
+	Annotations: map[string]string{
+		manualAnnotation: `Delete one or more registered branches by NAME or ALIAS, removing both the git branch and its registry entry.
+Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the remote branch), --remote-only, -i/--ignore-errors, -w/--worktree (also remove its worktree).`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return internal.GetBranchesAndAliases()
 	},

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -28,6 +28,9 @@ var getCmd = &cobra.Command{
 
 - get delete-branches-worktree: Get the delete-branches-worktree setting
 `,
+	Annotations: map[string]string{
+		manualAnnotation: `Read a configuration value. Sub-commands: default-branch, local-prefix, global-prefix, home, worktree-path, delete-branches-worktree.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		commands := []string{"default-branch", "local-prefix", "global-prefix", "home", "worktree-path", "delete-branches-worktree"}

--- a/cmd/getBranchAlias.go
+++ b/cmd/getBranchAlias.go
@@ -15,6 +15,9 @@ var getBranchAliasCmd = &cobra.Command{
 	Long:    `Gets the branch alias`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: []string{"get-branch-alias", "gbr"},
+	Annotations: map[string]string{
+		manualAnnotation: `Print the alias registered for the given branch NAME.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,6 +11,9 @@ var listCmd = &cobra.Command{
 	Short:   "Lists all branches with their name, alias, and notes",
 	Long:    `Lists all branches with their name, alias, and notes`,
 	Aliases: []string{"ls", "l"},
+	Annotations: map[string]string{
+		manualAnnotation: `List all registered branches with their name, alias, note, and any associated worktree.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// manualAnnotation is the Annotations map key under which each top-level command
+// stores its brief, LLM-friendly manual text.
+const manualAnnotation = "manual"
+
+// importantCommands are the core commands documented by `g man` without --full,
+// listed in the order they should be printed.
+var importantCommands = []string{
+	"create", "delete", "switch", "merge", "currentBranch", "list", "worktree",
+}
+
+// manCmd represents the man command
+var manCmd = &cobra.Command{
+	Use:   "man",
+	Short: "Prints an LLM-friendly guide on how to use this tool",
+	Long: `Prints a concise, LLM-friendly guide on how to use this tool.
+
+By default only the most important commands are documented. Use --full to print
+the manual for every command. Run "g <command> --help" for the full flags and
+details of any individual command.`,
+	Aliases: []string{"manual"},
+	Args:    cobra.NoArgs,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		full, _ := cmd.Flags().GetBool("full")
+		fmt.Print(buildManual(full))
+	},
+}
+
+// buildManual assembles the usage guide from the manual annotation of each
+// top-level command. When full is false, only importantCommands are included.
+func buildManual(full bool) string {
+	var b strings.Builder
+
+	b.WriteString("# g (gitBranchTool) — Command Guide\n\n")
+	b.WriteString("`g` manages git branches by registering short, memorable aliases (and notes)\n")
+	b.WriteString("for long or cryptic branch names, and can manage git worktrees. Most commands\n")
+	b.WriteString("accept a branch NAME or its ALIAS interchangeably.\n")
+	b.WriteString("Run `g <command> --help` for the full flags and details of any command.\n\n")
+
+	// Index top-level commands by name for ordered lookup.
+	byName := map[string]*cobra.Command{}
+	for _, c := range rootCmd.Commands() {
+		byName[c.Name()] = c
+	}
+
+	// Always emit the important commands first, in their defined order.
+	emitted := map[string]bool{}
+	for _, name := range importantCommands {
+		if c, ok := byName[name]; ok {
+			writeCommandManual(&b, c)
+			emitted[name] = true
+		}
+	}
+
+	if !full {
+		b.WriteString("---\n")
+		b.WriteString("Only the core commands are shown. Run `g manual --full` for the full list of commands.\n")
+		return b.String()
+	}
+
+	// With --full, append every remaining documented command, sorted by name.
+	// Hidden helper commands are skipped from the printed guide.
+	var rest []string
+	for name, c := range byName {
+		if emitted[name] || c.Hidden {
+			continue
+		}
+		if c.Annotations[manualAnnotation] == "" {
+			continue
+		}
+		rest = append(rest, name)
+	}
+	sort.Strings(rest)
+	for _, name := range rest {
+		writeCommandManual(&b, byName[name])
+	}
+
+	return b.String()
+}
+
+// writeCommandManual writes a single command's manual block to b.
+func writeCommandManual(b *strings.Builder, c *cobra.Command) {
+	manual := c.Annotations[manualAnnotation]
+	if manual == "" {
+		return
+	}
+	b.WriteString("## " + c.Name())
+	if len(c.Aliases) > 0 {
+		b.WriteString("  (aliases: " + strings.Join(c.Aliases, ", ") + ")")
+	}
+	b.WriteString("\n")
+	b.WriteString("Usage: g " + c.Use + "\n")
+	b.WriteString(manual + "\n\n")
+}
+
+func init() {
+	rootCmd.AddCommand(manCmd)
+	manCmd.Flags().BoolP("full", "f", false, "Print the manual for all commands, not just the important ones")
+	manCmd.Annotations = map[string]string{
+		manualAnnotation: `Print this LLM-friendly usage guide. By default only the core commands are shown; use -f/--full to document every command.`,
+	}
+}

--- a/cmd/man_test.go
+++ b/cmd/man_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// cobraGeneratedCommands are commands Cobra adds automatically; they do not
+// carry a manual annotation and are excluded from the guide.
+var cobraGeneratedCommands = map[string]bool{
+	"help":       true,
+	"completion": true,
+}
+
+func TestBuildManualDefaultOnlyImportant(t *testing.T) {
+	out := buildManual(false)
+
+	for _, name := range importantCommands {
+		if !strings.Contains(out, "## "+name) {
+			t.Errorf("default manual is missing important command %q", name)
+		}
+	}
+
+	// Non-important commands must not appear without --full.
+	for _, name := range []string{"addAlias", "rename", "removeEntry", "updateCheck"} {
+		if strings.Contains(out, "## "+name) {
+			t.Errorf("default manual should not include non-important command %q", name)
+		}
+	}
+}
+
+func TestBuildManualFullIncludesAllDocumented(t *testing.T) {
+	out := buildManual(true)
+
+	for _, c := range rootCmd.Commands() {
+		name := c.Name()
+		if cobraGeneratedCommands[name] {
+			continue
+		}
+		// Hidden helpers (e.g. _ps) carry a manual but are not printed.
+		if c.Hidden {
+			if strings.Contains(out, "## "+name) {
+				t.Errorf("full manual should not include hidden command %q", name)
+			}
+			continue
+		}
+		if !strings.Contains(out, "## "+name) {
+			t.Errorf("full manual is missing command %q", name)
+		}
+	}
+}
+
+func TestEveryTopLevelCommandHasManual(t *testing.T) {
+	for _, c := range rootCmd.Commands() {
+		if cobraGeneratedCommands[c.Name()] {
+			continue
+		}
+		if strings.TrimSpace(c.Annotations[manualAnnotation]) == "" {
+			t.Errorf("command %q is missing a %q annotation", c.Name(), manualAnnotation)
+		}
+	}
+}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -30,6 +30,10 @@ Examples:
 	g merge --continue      Continue after resolving conflicts`,
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"m"},
+	Annotations: map[string]string{
+		manualAnnotation: `Merge (or rebase) the branch with the given NAME/ALIAS into the current branch. With no argument, uses the configured default branch (a quick way to sync the current branch with main).
+Flags: -r/--rebase, -s/--squash, -f/--fetch (fetch from origin first), --ff-only, --no-ff, -n/--no-verify, --continue and --abort (for an in-progress merge/rebase).`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/promptString.go
+++ b/cmd/promptString.go
@@ -17,6 +17,9 @@ var promptStringCmd = &cobra.Command{
 	Short:  "Returns the prompt string - used for the custom prompt",
 	Long:   `Returns the prompt string - used for the custom prompt`,
 	Hidden: true,
+	Annotations: map[string]string{
+		manualAnnotation: `Internal helper that prints the shell prompt string for g's custom prompt integration. Not intended for direct use.`,
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		prompt := ""
 		if runtime.GOOS == "windows" {

--- a/cmd/removeEntry.go
+++ b/cmd/removeEntry.go
@@ -12,6 +12,9 @@ var removeEntryCmd = &cobra.Command{
 	Short:   "Removes a registered branch entry without deleting the branch",
 	Long:    `Removes a registered branch entry without deleting the branch",`,
 	Aliases: []string{"remove-entry", "re"},
+	Annotations: map[string]string{
+		manualAnnotation: `Remove a branch's registry entry (alias/note) without deleting the actual git branch.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -13,6 +13,9 @@ var renameCmd = &cobra.Command{
 	Long:    `Updates the alias for the given branch name.`,
 	Args:    cobra.ExactArgs(2),
 	Aliases: []string{"mv", "updateBranchAlias", "update-branch-alias", "uba"},
+	Annotations: map[string]string{
+		manualAnnotation: `Change the registered ALIAS for the given branch NAME.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/resolveAlias.go
+++ b/cmd/resolveAlias.go
@@ -17,6 +17,9 @@ var resolveAliasCmd = &cobra.Command{
 	Example: git merge $(g r ALIAS)`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: []string{"resolve-alias", "r"},
+	Annotations: map[string]string{
+		manualAnnotation: `Print the branch name that an ALIAS maps to. Useful in scripts, e.g. git merge $(g r ALIAS).`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -33,6 +33,9 @@ Default is "./worktrees/{alias}" (Run command with no argument to reset to defau
 true: auto-delete worktree, false: never auto-delete, null: prompt user (default)
 	Example: g set delete-branches-worktree true
 `,
+	Annotations: map[string]string{
+		manualAnnotation: `Change a configuration value. Sub-commands: default-branch <NAME>, local-prefix <PREFIX>, global-prefix <PREFIX>, worktree-path <TEMPLATE>, delete-branches-worktree <true|false|null>.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		commands := []string{"default-branch", "local-prefix", "global-prefix", "worktree-path", "delete-branches-worktree"}

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -20,6 +20,11 @@ For example:
 	g switch NAME ALIAS [...NOTE]`,
 	Args:    cobra.MinimumNArgs(1),
 	Aliases: []string{"checkout", "check", "s"},
+	Annotations: map[string]string{
+		manualAnnotation: `Switch to the branch with the given NAME or ALIAS (git checkout).
+Can also register and switch to a new branch in one step: g switch NAME ALIAS [...NOTE].
+Flag: -w/--worktree[=ALIAS] to find or create a worktree for the branch.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/updateBranchNote.go
+++ b/cmd/updateBranchNote.go
@@ -12,6 +12,9 @@ var updateBranchNoteCmd = &cobra.Command{
 	Short: "Adds/updates the notes for a branch base on name/alias",
 	Long:  `Adds/updates the notes for a branch base on name/alias`,
 	Args:  cobra.MinimumNArgs(2),
+	Annotations: map[string]string{
+		manualAnnotation: `Add or update the NOTE for a branch identified by NAME or ALIAS.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		position := len(args) + 1
 		if position == 1 {

--- a/cmd/updateCheck.go
+++ b/cmd/updateCheck.go
@@ -25,6 +25,9 @@ var updateCheckCmd = &cobra.Command{
 	Short:   "Checks if a newer version is available",
 	Long:    `Checks if a newer version is available. Asks to upgrade if available",`,
 	Aliases: []string{"update-check", "uc"},
+	Annotations: map[string]string{
+		manualAnnotation: `Check whether a newer version of the tool is available and optionally upgrade. Flag: -y/--yes-to-all to update without prompting.`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	},

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -28,6 +28,10 @@ var worktreeCmd = &cobra.Command{
 	Example: g worktree prune
 `,
 	Aliases: []string{"w"},
+	Annotations: map[string]string{
+		manualAnnotation: `Manage git worktrees. Run with no sub-command to list the current worktrees.
+Sub-commands: create ALIAS [BRANCH] [...NOTE] (new worktree), list, delete [...PATH|ALIAS] [-f/--force], prune (remove stale entries).`,
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"create", "list", "delete", "prune"}, cobra.ShellCompDirectiveNoFileComp
 	},


### PR DESCRIPTION
## Summary

Adds a new `g man` command (alias `g manual`) that prints a concise, **LLM-friendly** guide on how to use the tool — meant to be dropped into an AI assistant's context so it can drive `g` without reading every `--help` page.

- **`g man`** — documents only the core commands: `create`, `delete`, `switch`, `merge`, `currentBranch`, `list`, `worktree` (the minimum needed to be productive). Output ends with a pointer to run `g manual --full`.
- **`g man --full` / `g man -f`** — documents every command.

## How it works

Since `cobra.Command` is a fixed third-party struct, each top-level command now carries its manual text in the built-in `Annotations` map (key `manual`) — the idiomatic Cobra way to attach custom metadata. `buildManual()` assembles the guide from those annotations: core commands first (in a fixed order), then the rest alphabetically with `--full`. Hidden helpers (`_ps`) are excluded from the printed output. Each manual stays brief and points readers to `g <command> --help` for full flag-level detail.

## Changes

- New `cmd/man.go` — `manCmd`, `manualAnnotation`, `importantCommands`, `buildManual`.
- New `cmd/man_test.go` — verifies default vs `--full` contents and guards against any future top-level command forgetting its `manual` annotation.
- Added a `manual` annotation to every top-level command.
- README: added `man` to the command listing and a new **Manual (LLM Guide)** section.

## Testing

- `go build ./...`, `go vet ./cmd/...`, and `go test ./...` all pass.
- Smoke-tested: `g man` → core commands + footer, `g man --full`/`-f`/`g manual --full` → all commands, `_ps` excluded, `g man extra` errors (NoArgs).

> Note: version bump + `CHANGE_LOGS.md` entry intentionally left for the maintainer's `chore: release` step.