### PR TITLE
fix: add regex option for `g delete` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,15 @@ g d banner
 g d banner cyrus/jira-50930
 ```
 
+- **Delete branches matching a regular expression**
+
+With `--regex`/`-e`, the arguments are treated as regular expressions and every registered branch whose name or alias matches is deleted.
+
+```bash
+g d -e "claude.*"
+g d -e "cyrus/.*" "rel-[1-3]/beta"
+```
+
 - **Set branch name prefix for current repository**
 
 ```bash

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/cyrus2281/gitBranchTool/internal"
 	"github.com/cyrus2281/go-logger"
@@ -15,12 +16,15 @@ var deleteCmd = &cobra.Command{
 	Long: `Deletes listed branches base on name or alias (requires at least one name/alias)"
 
 	Without safe-delete uses the git command \"git branch -D [...NAME|ALIAS] \"
-	With safe-delete uses the git command \"git branch [...NAME|ALIAS] \"`,
+	With safe-delete uses the git command \"git branch [...NAME|ALIAS] \"
+
+	With --regex/-e, the arguments are treated as regular expressions and every
+	registered branch whose name or alias matches is deleted.`,
 	Args:    cobra.MinimumNArgs(1),
 	Aliases: []string{"del", "d"},
 	Annotations: map[string]string{
 		manualAnnotation: `Delete one or more registered branches by NAME or ALIAS, removing both the git branch and its registry entry.
-Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the remote branch), --remote-only, -i/--ignore-errors, -w/--worktree (also remove its worktree).`,
+Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the remote branch), --remote-only, -i/--ignore-errors, -w/--worktree (also remove its worktree), -e/--regex (treat arguments as regular expressions matched against branch names and aliases).`,
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return internal.GetBranchesAndAliases()
@@ -36,7 +40,17 @@ Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the
 		remote, _ := cmd.Flags().GetBool("remote")
 		remoteOnly, _ := cmd.Flags().GetBool("remote-only")
 		forceWorktree, _ := cmd.Flags().GetBool("worktree")
+		regex, _ := cmd.Flags().GetBool("regex")
 		repoBranches := internal.GetRepositoryBranches()
+
+		targets, err := resolveDeleteTargets(&repoBranches, args, regex)
+		if err != nil {
+			logger.Fatalln(err)
+		}
+		if regex && len(targets) == 0 {
+			logger.InfoF("No registered branches matched the given pattern(s)\n")
+			return
+		}
 
 		deleteBranchesWorktree := internal.GetConfig(internal.DELETE_BRANCHES_WORKTREE_KEY)
 		var worktreeMap map[string]string
@@ -47,7 +61,7 @@ Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the
 			}
 		}
 
-		for _, item := range args {
+		for _, item := range targets {
 			shouldDeleteWt := false
 			if worktreeMap != nil {
 				branch, ok := repoBranches.GetBranchByNameOrAlias(item)
@@ -90,6 +104,42 @@ type deleteOpts struct {
 	RemoteOnly           bool
 	ShouldDeleteWorktree bool
 	WorktreeMap          map[string]string
+}
+
+// resolveDeleteTargets expands the provided args into the list of items to delete.
+// When useRegex is false, the args are returned unchanged (each treated as a
+// literal NAME or ALIAS). When useRegex is true, each arg is compiled as a
+// regular expression and matched against every registered branch's name and
+// alias; the names of all matching branches are returned (de-duplicated, in
+// registry order).
+func resolveDeleteTargets(repoBranches *internal.RepositoryBranches, args []string, useRegex bool) ([]string, error) {
+	if !useRegex {
+		return args, nil
+	}
+
+	patterns := make([]*regexp.Regexp, 0, len(args))
+	for _, arg := range args {
+		re, err := regexp.Compile(arg)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regular expression \"%v\": %w", arg, err)
+		}
+		patterns = append(patterns, re)
+	}
+
+	seen := make(map[string]bool)
+	targets := []string{}
+	for _, branch := range repoBranches.GetBranches() {
+		for _, re := range patterns {
+			if re.MatchString(branch.Name) || re.MatchString(branch.Alias) {
+				if !seen[branch.Name] {
+					seen[branch.Name] = true
+					targets = append(targets, branch.Name)
+				}
+				break
+			}
+		}
+	}
+	return targets, nil
 }
 
 func executeDeleteBranch(git *internal.Git, repoBranches *internal.RepositoryBranches,
@@ -147,4 +197,5 @@ func init() {
 	deleteCmd.Flags().BoolP("remote", "r", false, "Delete the remote branch as well")
 	deleteCmd.Flags().Bool("remote-only", false, "Deletes only the remote branch. Local branch and registry entry are not removed")
 	deleteCmd.Flags().BoolP("worktree", "w", false, "Also delete the associated worktree")
+	deleteCmd.Flags().BoolP("regex", "e", false, "Treat the arguments as regular expressions matched against branch names and aliases")
 }

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -172,6 +172,105 @@ func TestExecuteDeleteBranch_MultipleInSequence(t *testing.T) {
 	}
 }
 
+func TestResolveDeleteTargets_NoRegexReturnsArgsUnchanged(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "feature/a", Alias: "a"})
+
+	args := []string{"feature/a", "b", "nonexistent"}
+	targets, err := resolveDeleteTargets(store, args, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != len(args) {
+		t.Fatalf("expected args returned unchanged, got %v", targets)
+	}
+	for i, v := range args {
+		if targets[i] != v {
+			t.Errorf("expected targets[%d]=%q, got %q", i, v, targets[i])
+		}
+	}
+}
+
+func TestResolveDeleteTargets_MatchesByName(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "claude/one", Alias: "c1"})
+	store.AddBranch(internal.Branch{Name: "claude/two", Alias: "c2"})
+	store.AddBranch(internal.Branch{Name: "feature/keep", Alias: "keep"})
+
+	targets, err := resolveDeleteTargets(store, []string{"claude.*"}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 matches, got %d (%v)", len(targets), targets)
+	}
+	for _, name := range targets {
+		if name == "feature/keep" {
+			t.Error("non-matching branch should not be a target")
+		}
+	}
+}
+
+func TestResolveDeleteTargets_MatchesByAlias(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "feature/login", Alias: "rel-1/beta"})
+	store.AddBranch(internal.Branch{Name: "feature/logout", Alias: "rel-9/beta"})
+
+	targets, err := resolveDeleteTargets(store, []string{"rel-[1-3]/beta"}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 || targets[0] != "feature/login" {
+		t.Fatalf("expected only feature/login matched by alias, got %v", targets)
+	}
+}
+
+func TestResolveDeleteTargets_MultiplePatternsDeduped(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "cyrus/jira-1", Alias: "j1"})
+	store.AddBranch(internal.Branch{Name: "cyrus/jira-2", Alias: "j2"})
+	store.AddBranch(internal.Branch{Name: "rel-2/beta", Alias: "rb"})
+
+	// Two patterns; "cyrus/.*" also overlaps nothing with the second, but the
+	// branch order must be preserved and no branch may appear twice.
+	targets, err := resolveDeleteTargets(store, []string{"cyrus/.*", "rel-[1-3]/beta"}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 3 {
+		t.Fatalf("expected 3 matches, got %d (%v)", len(targets), targets)
+	}
+	expected := []string{"cyrus/jira-1", "cyrus/jira-2", "rel-2/beta"}
+	for i, name := range expected {
+		if targets[i] != name {
+			t.Errorf("expected targets[%d]=%q, got %q", i, name, targets[i])
+		}
+	}
+}
+
+func TestResolveDeleteTargets_NoMatches(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "feature/a", Alias: "a"})
+
+	targets, err := resolveDeleteTargets(store, []string{"nomatch.*"}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Errorf("expected no matches, got %v", targets)
+	}
+}
+
+func TestResolveDeleteTargets_InvalidRegex(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "feature/a", Alias: "a"})
+
+	_, err := resolveDeleteTargets(store, []string{"["}, true)
+	if err == nil {
+		t.Error("expected an error for an invalid regular expression")
+	}
+}
+
 func TestExecuteDeleteBranch_SafeDelete(t *testing.T) {
 	repoDir := initTestRepo(t)
 	chdir(t, repoDir)


### PR DESCRIPTION
## Summary

Implements [#41](https://github.com/cyrus2281/gitBranchTool/issues/41): a `--regex`/`-e` flag for `g delete`.

When passed, all keyword arguments are treated as regular expressions, and every registered branch whose **name or alias** matches any of the patterns is deleted (de-duplicated, in registry order).

```bash
g d -e "claude.*"
g d -e "cyrus/.*" "rel-[1-3]/beta"
```

All existing delete flags (`-s`, `-r`, `--remote-only`, `-i`, `-w`) continue to work together with `-e`.

## Behavior

- Patterns are matched against both branch **name** and **alias** (consistent with the existing "name or alias" semantics of `g delete`), using standard Go `regexp` (unanchored) matching.
- An invalid regular expression fails fast with a clear error before any branch is deleted.
- When no registered branch matches, the command reports `No registered branches matched the given pattern(s)` and exits without changes.

## Changes

- `cmd/delete.go`: new `-e/--regex` flag; `resolveDeleteTargets` helper expands patterns into matching branch names; `Run` deletes the resolved targets.
- `cmd/delete_test.go`: unit tests covering name/alias matching, multiple patterns + de-duplication, no-match, and invalid-regex cases.
- `README.md`: documents the new flag with examples.

## Testing

- `go build ./...`, `go vet ./cmd/`, and `go test ./...` all pass.
- Verified end-to-end against a sandbox repo: regex matching deletes both the git branches and their registry entries while leaving non-matching branches intact; no-match and invalid-regex edge cases behave as described.

Closes #41