### PR TITLE
feat: add --all flag to `g list` and `g delete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,14 @@ g a cyrus/jira-60083 banner "Adds banner to the home page"
 g l
 ```
 
+- **List registered and unregistered branches**
+
+With `--all`/`-a`, the registered branches are listed first (with their alias and note), followed by every other local git branch with an empty alias and note.
+
+```bash
+g l -a
+```
+
 - **Switch to branch**
 
 ```bash
@@ -324,6 +332,15 @@ With `--regex`/`-e`, the arguments are treated as regular expressions and every 
 ```bash
 g d -e "claude.*"
 g d -e "cyrus/.*" "rel-[1-3]/beta"
+```
+
+- **Delete branches that are not registered with `g`**
+
+With `--all`/`-a`, the candidate list is expanded with every local git branch before the search runs, so branches that were never registered with `g` can be deleted by name or by regex. Combine it with `-e` to clean up unregistered branches in bulk.
+
+```bash
+g d -a old-experiment
+g d -a -e "claude/.*"
 ```
 
 - **Set branch name prefix for current repository**

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -19,14 +19,21 @@ var deleteCmd = &cobra.Command{
 	With safe-delete uses the git command \"git branch [...NAME|ALIAS] \"
 
 	With --regex/-e, the arguments are treated as regular expressions and every
-	registered branch whose name or alias matches is deleted.`,
+	registered branch whose name or alias matches is deleted.
+
+	With --all/-a, branches that are not registered with g are also considered:
+	the candidate list is expanded with every local git branch before the
+	search runs, so unregistered branches can be deleted by name or by regex.`,
 	Args:    cobra.MinimumNArgs(1),
 	Aliases: []string{"del", "d"},
 	Annotations: map[string]string{
 		manualAnnotation: `Delete one or more registered branches by NAME or ALIAS, removing both the git branch and its registry entry.
-Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the remote branch), --remote-only, -i/--ignore-errors, -w/--worktree (also remove its worktree), -e/--regex (treat arguments as regular expressions matched against branch names and aliases).`,
+Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the remote branch), --remote-only, -i/--ignore-errors, -w/--worktree (also remove its worktree), -e/--regex (treat arguments as regular expressions matched against branch names and aliases), -a/--all (also consider local git branches not registered with g, expanding the candidate list before searching/deleting).`,
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if all, _ := cmd.Flags().GetBool("all"); all {
+			return internal.GetAllBranchesAndAliases()
+		}
 		return internal.GetBranchesAndAliases()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -41,14 +48,21 @@ Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the
 		remoteOnly, _ := cmd.Flags().GetBool("remote-only")
 		forceWorktree, _ := cmd.Flags().GetBool("worktree")
 		regex, _ := cmd.Flags().GetBool("regex")
+		all, _ := cmd.Flags().GetBool("all")
 		repoBranches := internal.GetRepositoryBranches()
 
-		targets, err := resolveDeleteTargets(&repoBranches, args, regex)
+		// With --all, unregistered git branches are also candidates for deletion.
+		var gitBranches []string
+		if all {
+			gitBranches, _ = git.GetBranches()
+		}
+
+		targets, err := resolveDeleteTargets(&repoBranches, gitBranches, args, regex, all)
 		if err != nil {
 			logger.Fatalln(err)
 		}
 		if regex && len(targets) == 0 {
-			logger.InfoF("No registered branches matched the given pattern(s)\n")
+			logger.InfoF("No branches matched the given pattern(s)\n")
 			return
 		}
 
@@ -64,21 +78,25 @@ Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the
 		for _, item := range targets {
 			shouldDeleteWt := false
 			if worktreeMap != nil {
-				branch, ok := repoBranches.GetBranchByNameOrAlias(item)
-				if ok {
-					wtPath := internal.GetWorktreePathForBranch(worktreeMap, branch.Name)
-					if wtPath != "" {
-						if forceWorktree || deleteBranchesWorktree == "true" {
-							shouldDeleteWt = true
-						} else if deleteBranchesWorktree != "false" {
-							logger.InfoF("Branch \"%s\" is checked out in worktree at %s\n", branch.Name, wtPath)
-							logger.InfoF("Delete the worktree as well? (y/n): ")
-							var response string
-							if _, err := fmt.Scanln(&response); err != nil {
-								logger.WarningF("Failed to read response, defaulting to not deleting worktree: %v\n", err)
-							} else {
-								shouldDeleteWt = response == "y" || response == "Y" || response == "yes"
-							}
+				// Resolve to the branch name, falling back to the item itself
+				// so unregistered branches (only reachable with --all) still
+				// have their worktree detected.
+				branchName := item
+				if branch, ok := repoBranches.GetBranchByNameOrAlias(item); ok {
+					branchName = branch.Name
+				}
+				wtPath := internal.GetWorktreePathForBranch(worktreeMap, branchName)
+				if wtPath != "" {
+					if forceWorktree || deleteBranchesWorktree == "true" {
+						shouldDeleteWt = true
+					} else if deleteBranchesWorktree != "false" {
+						logger.InfoF("Branch \"%s\" is checked out in worktree at %s\n", branchName, wtPath)
+						logger.InfoF("Delete the worktree as well? (y/n): ")
+						var response string
+						if _, err := fmt.Scanln(&response); err != nil {
+							logger.WarningF("Failed to read response, defaulting to not deleting worktree: %v\n", err)
+						} else {
+							shouldDeleteWt = response == "y" || response == "Y" || response == "yes"
 						}
 					}
 				}
@@ -91,6 +109,7 @@ Flags: -s/--safe-delete (refuse unmerged branches), -r/--remote (also delete the
 				RemoteOnly:           remoteOnly,
 				ShouldDeleteWorktree: shouldDeleteWt,
 				WorktreeMap:          worktreeMap,
+				All:                  all,
 			}
 			executeDeleteBranch(&git, &repoBranches, item, opts)
 		}
@@ -104,6 +123,9 @@ type deleteOpts struct {
 	RemoteOnly           bool
 	ShouldDeleteWorktree bool
 	WorktreeMap          map[string]string
+	// All allows deleting a git branch that is not registered with g, treating
+	// the item as a raw branch name when it is not found in the registry.
+	All bool
 }
 
 // resolveDeleteTargets expands the provided args into the list of items to delete.
@@ -112,7 +134,12 @@ type deleteOpts struct {
 // regular expression and matched against every registered branch's name and
 // alias; the names of all matching branches are returned (de-duplicated, in
 // registry order).
-func resolveDeleteTargets(repoBranches *internal.RepositoryBranches, args []string, useRegex bool) ([]string, error) {
+//
+// When all is true, the regex search is additionally run against gitBranches
+// (the local git branch names), so unregistered branches matched by a pattern
+// are appended after the registered matches. all has no effect when useRegex
+// is false, where unregistered names are handled at delete time instead.
+func resolveDeleteTargets(repoBranches *internal.RepositoryBranches, gitBranches []string, args []string, useRegex bool, all bool) ([]string, error) {
 	if !useRegex {
 		return args, nil
 	}
@@ -139,6 +166,20 @@ func resolveDeleteTargets(repoBranches *internal.RepositoryBranches, args []stri
 			}
 		}
 	}
+	if all {
+		for _, name := range gitBranches {
+			if seen[name] {
+				continue
+			}
+			for _, re := range patterns {
+				if re.MatchString(name) {
+					seen[name] = true
+					targets = append(targets, name)
+					break
+				}
+			}
+		}
+	}
 	return targets, nil
 }
 
@@ -147,8 +188,14 @@ func executeDeleteBranch(git *internal.Git, repoBranches *internal.RepositoryBra
 
 	branch, ok := repoBranches.GetBranchByNameOrAlias(item)
 	if !ok {
-		logger.InfoF("Branch/Alias \"%v\" not found\n", item)
-		return
+		if !opts.All {
+			logger.InfoF("Branch/Alias \"%v\" not found\n", item)
+			return
+		}
+		// With --all, the item is treated as a raw git branch name. There is no
+		// registry entry to remove; the git delete below reports an error if no
+		// such branch exists.
+		branch = internal.Branch{Name: item}
 	}
 
 	// Delete worktree FIRST if needed (git won't let us delete a branch checked out in a worktree)
@@ -176,8 +223,13 @@ func executeDeleteBranch(git *internal.Git, repoBranches *internal.RepositoryBra
 		}
 
 		if err == nil || opts.IgnoreErrors {
+			// RemoveBranch is a no-op for unregistered branches (no matching entry).
 			repoBranches.RemoveBranch(branch)
-			logger.InfoF("Branch \"%v\" with alias \"%v\" was deleted\n", branch.Name, branch.Alias)
+			if branch.Alias != "" {
+				logger.InfoF("Branch \"%v\" with alias \"%v\" was deleted\n", branch.Name, branch.Alias)
+			} else {
+				logger.InfoF("Branch \"%v\" was deleted\n", branch.Name)
+			}
 		}
 	}
 	if (err == nil || opts.IgnoreErrors) && (opts.Remote || opts.RemoteOnly) {
@@ -198,4 +250,5 @@ func init() {
 	deleteCmd.Flags().Bool("remote-only", false, "Deletes only the remote branch. Local branch and registry entry are not removed")
 	deleteCmd.Flags().BoolP("worktree", "w", false, "Also delete the associated worktree")
 	deleteCmd.Flags().BoolP("regex", "e", false, "Treat the arguments as regular expressions matched against branch names and aliases")
+	deleteCmd.Flags().BoolP("all", "a", false, "Also consider local git branches not registered with g, expanding the candidate list before searching/deleting")
 }

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -177,7 +177,7 @@ func TestResolveDeleteTargets_NoRegexReturnsArgsUnchanged(t *testing.T) {
 	store.AddBranch(internal.Branch{Name: "feature/a", Alias: "a"})
 
 	args := []string{"feature/a", "b", "nonexistent"}
-	targets, err := resolveDeleteTargets(store, args, false)
+	targets, err := resolveDeleteTargets(store, nil, args, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestResolveDeleteTargets_MatchesByName(t *testing.T) {
 	store.AddBranch(internal.Branch{Name: "claude/two", Alias: "c2"})
 	store.AddBranch(internal.Branch{Name: "feature/keep", Alias: "keep"})
 
-	targets, err := resolveDeleteTargets(store, []string{"claude.*"}, true)
+	targets, err := resolveDeleteTargets(store, nil, []string{"claude.*"}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestResolveDeleteTargets_MatchesByAlias(t *testing.T) {
 	store.AddBranch(internal.Branch{Name: "feature/login", Alias: "rel-1/beta"})
 	store.AddBranch(internal.Branch{Name: "feature/logout", Alias: "rel-9/beta"})
 
-	targets, err := resolveDeleteTargets(store, []string{"rel-[1-3]/beta"}, true)
+	targets, err := resolveDeleteTargets(store, nil, []string{"rel-[1-3]/beta"}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestResolveDeleteTargets_MultiplePatternsDeduped(t *testing.T) {
 
 	// Two patterns; "cyrus/.*" also overlaps nothing with the second, but the
 	// branch order must be preserved and no branch may appear twice.
-	targets, err := resolveDeleteTargets(store, []string{"cyrus/.*", "rel-[1-3]/beta"}, true)
+	targets, err := resolveDeleteTargets(store, nil, []string{"cyrus/.*", "rel-[1-3]/beta"}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestResolveDeleteTargets_NoMatches(t *testing.T) {
 	store := newTestStore(t)
 	store.AddBranch(internal.Branch{Name: "feature/a", Alias: "a"})
 
-	targets, err := resolveDeleteTargets(store, []string{"nomatch.*"}, true)
+	targets, err := resolveDeleteTargets(store, nil, []string{"nomatch.*"}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -265,9 +265,87 @@ func TestResolveDeleteTargets_InvalidRegex(t *testing.T) {
 	store := newTestStore(t)
 	store.AddBranch(internal.Branch{Name: "feature/a", Alias: "a"})
 
-	_, err := resolveDeleteTargets(store, []string{"["}, true)
+	_, err := resolveDeleteTargets(store, nil, []string{"["}, true, false)
 	if err == nil {
 		t.Error("expected an error for an invalid regular expression")
+	}
+}
+
+func TestResolveDeleteTargets_AllRegexMatchesUnregistered(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "claude/one", Alias: "c1"})
+
+	gitBranches := []string{"claude/one", "claude/two", "main"}
+	targets, err := resolveDeleteTargets(store, gitBranches, []string{"claude/.*"}, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Registered "claude/one" comes first, then the unregistered "claude/two".
+	expected := []string{"claude/one", "claude/two"}
+	if len(targets) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, targets)
+	}
+	for i, name := range expected {
+		if targets[i] != name {
+			t.Errorf("expected targets[%d]=%q, got %q", i, name, targets[i])
+		}
+	}
+}
+
+func TestResolveDeleteTargets_AllFalseIgnoresUnregistered(t *testing.T) {
+	store := newTestStore(t)
+	store.AddBranch(internal.Branch{Name: "claude/one", Alias: "c1"})
+
+	gitBranches := []string{"claude/one", "claude/two"}
+	// all=false → the unregistered "claude/two" must not be matched.
+	targets, err := resolveDeleteTargets(store, gitBranches, []string{"claude/.*"}, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 || targets[0] != "claude/one" {
+		t.Fatalf("expected only registered claude/one, got %v", targets)
+	}
+}
+
+func TestExecuteDeleteBranch_AllDeletesUnregistered(t *testing.T) {
+	repoDir := initTestRepo(t)
+	chdir(t, repoDir)
+	store := newTestStore(t)
+	git := internal.Git{}
+
+	// Branch exists in git but is not registered with g.
+	git.CreateNewBranch("feature/unregistered")
+
+	executeDeleteBranch(&git, store, "feature/unregistered", deleteOpts{Force: true, All: true})
+
+	branches, _ := git.GetBranches()
+	for _, b := range branches {
+		if b == "feature/unregistered" {
+			t.Error("unregistered branch should be deleted from git with --all")
+		}
+	}
+}
+
+func TestExecuteDeleteBranch_UnregisteredSkippedWithoutAll(t *testing.T) {
+	repoDir := initTestRepo(t)
+	chdir(t, repoDir)
+	store := newTestStore(t)
+	git := internal.Git{}
+
+	git.CreateNewBranch("feature/unregistered")
+
+	// Without --all an unregistered branch is reported as not found and kept.
+	executeDeleteBranch(&git, store, "feature/unregistered", deleteOpts{Force: true})
+
+	branches, _ := git.GetBranches()
+	found := false
+	for _, b := range branches {
+		if b == "feature/unregistered" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("unregistered branch should remain when --all is not set")
 	}
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,17 +12,26 @@ var listCmd = &cobra.Command{
 	Long:    `Lists all branches with their name, alias, and notes`,
 	Aliases: []string{"ls", "l"},
 	Annotations: map[string]string{
-		manualAnnotation: `List all registered branches with their name, alias, note, and any associated worktree.`,
+		manualAnnotation: `List all registered branches with their name, alias, note, and any associated worktree.
+Flags: -a/--all (also list local git branches that are not registered with g, shown with empty alias and note after the registered ones).`,
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		all, _ := cmd.Flags().GetBool("all")
 		repoBranches := internal.GetRepositoryBranches()
 		branches := repoBranches.GetBranches()
 
-		// Check git worktree list for ANY worktrees (not just stored ones)
 		git := internal.Git{}
+
+		// With --all, append every local git branch that is not registered,
+		// listed after the registered branches with empty alias and note.
+		if all {
+			branches = appendUnregisteredBranches(&git, branches)
+		}
+
+		// Check git worktree list for ANY worktrees (not just stored ones)
 		worktreeListOutput, _ := git.WorktreeList()
 		worktreeMap := internal.ParseWorktreeList(worktreeListOutput)
 
@@ -41,7 +50,7 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-		// Determine if any registered branch has a worktree
+		// Determine if any listed branch has a worktree
 		hasWorktrees := false
 		for _, branch := range branches {
 			if _, ok := branchToWorktreeInfo[branch.Name]; ok {
@@ -68,6 +77,32 @@ var listCmd = &cobra.Command{
 	},
 }
 
+// appendUnregisteredBranches returns a new slice containing every registered
+// branch followed by each local git branch that is not already registered.
+// Unregistered branches carry only their name (empty alias and note). If the
+// git branch list cannot be read, the registered branches are returned as-is.
+func appendUnregisteredBranches(git *internal.Git, registered []internal.Branch) []internal.Branch {
+	result := make([]internal.Branch, len(registered))
+	copy(result, registered)
+
+	gitBranches, err := git.GetBranches()
+	if err != nil {
+		return result
+	}
+
+	registeredNames := make(map[string]bool, len(registered))
+	for _, b := range registered {
+		registeredNames[b.Name] = true
+	}
+	for _, name := range gitBranches {
+		if !registeredNames[name] {
+			result = append(result, internal.Branch{Name: name})
+		}
+	}
+	return result
+}
+
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().BoolP("all", "a", false, "Also list local git branches that are not registered with g (shown with empty alias and note)")
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cyrus2281/gitBranchTool/internal"
+)
+
+func TestAppendUnregisteredBranches(t *testing.T) {
+	repoDir := initTestRepo(t)
+	chdir(t, repoDir)
+	git := internal.Git{}
+
+	// initTestRepo creates an initial commit on the default branch.
+	defaultBranch, _ := git.GetCurrentBranch()
+
+	git.CreateNewBranch("feature/registered")
+	git.CreateNewBranch("feature/loose")
+
+	registered := []internal.Branch{
+		{Name: "feature/registered", Alias: "reg", Note: "note"},
+	}
+
+	result := appendUnregisteredBranches(&git, registered)
+
+	// Registered branch must come first and keep its alias/note.
+	if len(result) == 0 || result[0].Name != "feature/registered" || result[0].Alias != "reg" {
+		t.Fatalf("expected registered branch first with alias, got %+v", result)
+	}
+
+	byName := map[string]internal.Branch{}
+	for _, b := range result {
+		byName[b.Name] = b
+	}
+
+	// The loose branch must appear with empty alias/note.
+	loose, ok := byName["feature/loose"]
+	if !ok {
+		t.Fatal("expected unregistered branch feature/loose to be listed")
+	}
+	if loose.Alias != "" || loose.Note != "" {
+		t.Errorf("unregistered branch should have empty alias/note, got %+v", loose)
+	}
+
+	// The default branch is also unregistered and must be listed.
+	if _, ok := byName[defaultBranch]; !ok {
+		t.Errorf("expected default branch %q to be listed", defaultBranch)
+	}
+
+	// The registered branch must not be duplicated.
+	count := 0
+	for _, b := range result {
+		if b.Name == "feature/registered" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("registered branch should appear once, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `-a`/`--all` flag to both `g list` and `g delete`.

### `g list -a` / `g list --all`
Lists **all** branches: the ones registered with `g` first (with their alias and note — current behaviour), followed by every other local git branch with an empty alias and note.

```
   Branch Name          Alias   Note
----------------------------------------
0) feature/registered   reg     my note
1) feature/loose-1
2) loose-2
3) main
```

### `g delete -a` / `g delete --all`
Expands the candidate list with **all** local git branches before searching, so branches that were never registered with `g` can be deleted — by name or by regex (`-e`).

- `g d -a old-experiment` — delete an unregistered branch by name
- `g d -a -e "claude/.*"` — regex matches registered branches (name + alias) **and** unregistered git branch names; registered matches are listed first

Without `-a`, unregistered branches still report `Branch/Alias "x" not found` and are left untouched (unchanged behaviour). Worktree detection and `-w` work for unregistered branches too, and tab-completion uses the all-aware branch list when `-a` is set.

## Changes
- `cmd/list.go` — `--all` flag + `appendUnregisteredBranches` helper
- `cmd/delete.go` — `--all` flag, `resolveDeleteTargets` now matches regex against git branches, `executeDeleteBranch` handles unregistered branches, all-aware completion
- `README.md` — examples for both flags; updated `g man` annotations

## Testing
- `go build`, `go vet`, `go test ./...` all pass
- New tests in `cmd/delete_test.go` (regex/literal `--all` paths) and `cmd/list_test.go` (`appendUnregisteredBranches`)
- Manual end-to-end run confirmed list ordering and delete of registered + unregistered branches

> **Note:** version bump (`internal/version.go`) and `CHANGE_LOGS.md` entry are left for the release step, per the repo's separate `chore: release` convention.
