### PR TITLE
fix: strip worktree marker when parsing git branch output

### DIFF
--- a/internal/git.go
+++ b/internal/git.go
@@ -255,7 +255,8 @@ func (g *Git) GetBranches() ([]string, error) {
 }
 
 // parseBranchOutput parses the output of `git branch` into a list of branch names.
-// It strips the `*` marker from the current branch, trims whitespace,
+// It strips the leading marker git prepends to a branch (`*` for the current
+// branch, `+` for a branch checked out in a linked worktree), trims whitespace,
 // and filters out detached HEAD entries.
 func parseBranchOutput(output string) []string {
 	lines := strings.Split(output, "\n")
@@ -265,7 +266,7 @@ func parseBranchOutput(output string) []string {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "*") {
+		if strings.HasPrefix(line, "*") || strings.HasPrefix(line, "+") {
 			line = strings.TrimSpace(line[1:])
 		}
 		// Filter out detached HEAD entries like "(HEAD detached at abc123)"

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -32,6 +32,28 @@ func TestParseBranchOutput_SingleBranchWithStar(t *testing.T) {
 	}
 }
 
+func TestParseBranchOutput_SingleBranchWithWorktreeMarker(t *testing.T) {
+	// `git branch` prefixes a branch checked out in a linked worktree with "+".
+	result := parseBranchOutput("+ claude/fervent-pike-66c45e")
+	if len(result) != 1 || result[0] != "claude/fervent-pike-66c45e" {
+		t.Errorf("expected [claude/fervent-pike-66c45e], got %v", result)
+	}
+}
+
+func TestParseBranchOutput_MixedMarkers(t *testing.T) {
+	input := "+ claude/fervent-pike-66c45e\n+ claude/reverent-turing-a6fb33\n* main\n  some/new/branch\n  wow"
+	result := parseBranchOutput(input)
+	expected := []string{"claude/fervent-pike-66c45e", "claude/reverent-turing-a6fb33", "main", "some/new/branch", "wow"}
+	if len(result) != len(expected) {
+		t.Fatalf("expected %d branches, got %d: %v", len(expected), len(result), result)
+	}
+	for i, b := range expected {
+		if result[i] != b {
+			t.Errorf("index %d: expected %q, got %q", i, b, result[i])
+		}
+	}
+}
+
 func TestParseBranchOutput_MultipleBranches(t *testing.T) {
 	input := "* main\n  feature-a\n  bugfix-1"
 	result := parseBranchOutput(input)


### PR DESCRIPTION
## What

`parseBranchOutput` now strips a leading `+` marker (branch checked out in a linked worktree) in addition to the existing `*` marker (current branch) when parsing `git branch` output.

## Why

`git branch` prefixes a branch that is checked out in a linked worktree with `+ `:

```
+ claude/fervent-pike-66c45e   ← worktree marker
* main                          ← current branch
  some/new/branch               ← plain
```

`parseBranchOutput` only handled the `*` marker, so worktree branches were parsed with a literal `+ ` prefix (e.g. `+ claude/fervent-pike-66c45e`). When `g delete --all --regex` matched those names, it handed the malformed value to git and failed:

```
[WARNING] Failed to delete branch "+ claude/fervent-pike-66c45e", error: branch '+ claude/fervent-pike-66c45e' not found.
```

## Changes

- `internal/git.go`: strip a leading `+` as well as `*` in `parseBranchOutput`.
- `internal/git_test.go`: add `TestParseBranchOutput_SingleBranchWithWorktreeMarker` and `TestParseBranchOutput_MixedMarkers` (the latter reproduces the exact `git branch` output from the bug report).

## Notes for reviewers

This fixes the *parsing* only. Git itself refuses to delete a branch that is currently checked out in a worktree, so deleting such branches still requires `-w`/`--worktree` to remove the worktree first — that behavior is unchanged and out of scope here.

All tests pass (`go test ./...`).